### PR TITLE
🛡️ feat(ci): adopt weekly security digest + BondIT YY.MM.PATCH versioning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,81 @@
 version: 2
 
+# ──────────────────────────────────────────────────────────────────────────
+# Dependabot — security-updates only mode (org-wide standard)
+# ──────────────────────────────────────────────────────────────────────────
+# Routine version-update PRs are DISABLED via open-pull-requests-limit: 0.
+# The weekly digest at .github/workflows/weekly-security-report.yml is the
+# source of truth for routine bumps (Mondays 09:00 UTC).
+#
+# Security-update PRs (CVE response) are STILL ENABLED — they're a separate
+# Dependabot mode controlled by repo Settings → Code security → Dependabot
+# security updates. That toggle stays ON. When a CVE drops on a dependency
+# we use, Dependabot will still open a PR within hours.
+#
+# Ecosystems covered:
+#   - pip          → backend/requirements.txt  (ADDED — was previously missing!)
+#   - docker       → backend/Dockerfile
+#   - docker       → frontend/Dockerfile
+#   - github-actions → /.github/workflows/
+# ──────────────────────────────────────────────────────────────────────────
+
 updates:
-  # Scan for Docker updates in Dockerfile for backend
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Copenhagen"
+    open-pull-requests-limit: 0  # version-updates off; security-updates still flow
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
   - package-ecosystem: "docker"
     directory: "/backend"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Copenhagen"
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
 
-  # Scan for Docker updates in Dockerfile for frontend
   - package-ecosystem: "docker"
     directory: "/frontend"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Copenhagen"
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
 
-  # Include GitHub Actions workflows
   - package-ecosystem: "github-actions"
-    directory: "/.github/workflows"
+    directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Copenhagen"
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/version-increment.yml
+++ b/.github/workflows/version-increment.yml
@@ -1,0 +1,241 @@
+name: Auto-Increment Version on PR Merge
+
+# Automatically increments patch version when a PR is merged to main.
+# Versioning scheme: YY.MM.PATCH (e.g., 26.6.0, 26.6.1, …) — same as BondIT repos.
+# Patch counter resets on the first source change of each calendar month.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      force_version:
+        description: "Force specific version (e.g., 26.6.7)"
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-version-increment
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: read
+  actions: read
+
+jobs:
+  # ─────────────────────────────────────────────────────────────
+  # 🔍 DETECT SOURCE CHANGES
+  # ─────────────────────────────────────────────────────────────
+  # Skip the entire pipeline on doc-only / CI-only / dependabot-only commits.
+  # Source-relevant paths for homeassistant-tracker:
+  #   backend/    — Python app + requirements.txt + Dockerfile
+  #   frontend/   — static HTML/JS/CSS + Dockerfile + nginx.conf + entrypoint.sh
+  detect-changes:
+    name: "🔍 Detect Source Changes"
+    runs-on: ubuntu-latest
+    outputs:
+      source-changed: ${{ steps.check.outputs.source-changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+      - name: Check for source changes
+        id: check
+        run: |
+          CHANGED=$(git diff --name-only HEAD~1 HEAD)
+          echo "Changed files:"
+          echo "$CHANGED"
+          if echo "$CHANGED" | grep -qE "^(backend/|frontend/)"; then
+            echo "source-changed=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Source files changed — version increment will run"
+          else
+            echo "source-changed=false" >> "$GITHUB_OUTPUT"
+            echo "⚡ No source changes — skipping version increment"
+          fi
+
+  calculate-version:
+    name: "🔢 Calculate Next Version"
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.source-changed == 'true'
+    outputs:
+      new_version: ${{ steps.version.outputs.new_version }}
+      latest_version: ${{ steps.version.outputs.latest_version }}
+      current_month: ${{ steps.version.outputs.current_month }}
+      should_build: ${{ steps.check.outputs.should_build }}
+
+    steps:
+      - name: "📦 Checkout Repository"
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "🔢 Calculate Version"
+        id: version
+        run: |
+          if [[ -n "${{ github.event.inputs.force_version }}" ]]; then
+            NEW_VERSION="${{ github.event.inputs.force_version }}"
+            echo "🎯 Using forced version: $NEW_VERSION"
+
+            if ! [[ "$NEW_VERSION" =~ ^[0-9]{2}\.[0-9]{1,2}\.[0-9]+$ ]]; then
+              echo "❌ Invalid version format: $NEW_VERSION"
+              echo "Expected format: YY.MM.PATCH (e.g., 26.6.7)"
+              exit 1
+            fi
+
+            CURRENT_MONTH=$(date +"%y.%-m")
+            LATEST_VERSION=$(git tag -l "${CURRENT_MONTH}.*" | sort -V | tail -1)
+            if [[ -z "$LATEST_VERSION" ]]; then
+              LATEST_VERSION="${CURRENT_MONTH}.0"
+            fi
+          else
+            chmod +x scripts/increment-version.sh
+            ./scripts/increment-version.sh
+
+            NEW_VERSION=$(grep "NEW_VERSION=" "$GITHUB_OUTPUT" | cut -d'=' -f2)
+            LATEST_VERSION=$(grep "PREVIOUS_VERSION=" "$GITHUB_OUTPUT" | cut -d'=' -f2)
+            CURRENT_MONTH=$(echo "$NEW_VERSION" | cut -d'.' -f1-2)
+          fi
+
+          {
+            echo "new_version=$NEW_VERSION"
+            echo "latest_version=$LATEST_VERSION"
+            echo "current_month=$CURRENT_MONTH"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "📋 Version Calculation:"
+          echo "   Previous: $LATEST_VERSION"
+          echo "   Next:     $NEW_VERSION"
+          echo "   Month:    $CURRENT_MONTH"
+
+      - name: "🔍 Check if Version Already Exists"
+        id: check
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+        run: |
+          if git tag -l | grep -q "^${NEW_VERSION}$"; then
+            echo "⚠️ Version tag already exists: $NEW_VERSION"
+            if [[ "${{ github.event.inputs.force_version }}" == "$NEW_VERSION" ]]; then
+              echo "🔄 Force mode — will overwrite existing tag"
+              echo "should_build=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "ℹ️ Skipping for existing version"
+              echo "should_build=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "✅ New version ready: $NEW_VERSION"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  create-tag-and-release:
+    name: "🏷️ Create Tag and Release"
+    runs-on: ubuntu-latest
+    needs: [detect-changes, calculate-version]
+    if: needs.detect-changes.outputs.source-changed == 'true' && needs.calculate-version.outputs.should_build == 'true'
+
+    steps:
+      - name: "📦 Checkout Repository"
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: "🏷️ Create Git Tag"
+        env:
+          NEW_VERSION: ${{ needs.calculate-version.outputs.new_version }}
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+          if git tag -l | grep -q "^${NEW_VERSION}$"; then
+            echo "🔄 Removing existing tag: $NEW_VERSION"
+            git tag -d "$NEW_VERSION" || true
+          fi
+
+          git tag -a "$NEW_VERSION" -m "Patch release $NEW_VERSION
+
+          Automatic patch version increment from main branch merge.
+
+          Build: GitHub Actions #${GITHUB_RUN_NUMBER}
+          Commit: ${GITHUB_SHA:0:8}
+          Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          "
+          echo "✅ Created git tag: $NEW_VERSION"
+
+      - name: "📤 Push Tag"
+        env:
+          NEW_VERSION: ${{ needs.calculate-version.outputs.new_version }}
+        run: |
+          git push origin "$NEW_VERSION" --force
+          echo "✅ Pushed tag to origin: $NEW_VERSION"
+
+      - name: "📦 Create GitHub Release"
+        env:
+          NEW_VERSION: ${{ needs.calculate-version.outputs.new_version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat > temp_release_notes.md << EOF
+          # Release ${NEW_VERSION}
+
+          **Release Date:** $(date +"%Y-%m-%d")
+          **Release Type:** Patch Release
+          **Commit:** ${GITHUB_SHA:0:8}
+
+          ## Changes
+
+          Automatic patch release from main branch merge.
+
+          ## Technical Details
+
+          - **Git Tag:** \`${NEW_VERSION}\`
+          - **Version Update:** GitHub Actions #${GITHUB_RUN_NUMBER}
+          - **Docker Build:** Handled by separate \`docker-publish.yml\` workflow
+          EOF
+
+          gh release create "$NEW_VERSION" \
+            --title "Release $NEW_VERSION" \
+            --notes-file "temp_release_notes.md" \
+            --target main \
+            --generate-notes=false
+
+          echo "✅ Created GitHub release: $NEW_VERSION"
+
+  summary:
+    name: "📋 Version Summary"
+    runs-on: ubuntu-latest
+    needs: [detect-changes, calculate-version, create-tag-and-release]
+    if: always() && needs.detect-changes.outputs.source-changed == 'true'
+
+    steps:
+      - name: "📋 Generate Summary"
+        env:
+          NEW_VERSION: ${{ needs.calculate-version.outputs.new_version }}
+          SHOULD_BUILD: ${{ needs.calculate-version.outputs.should_build }}
+        run: |
+          {
+            echo "## 🚀 Version Increment Summary"
+            echo ""
+            echo "**Version:** $NEW_VERSION"
+            echo "**Trigger:** ${{ github.event_name }}"
+            echo "**Tag Created:** $SHOULD_BUILD"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$SHOULD_BUILD" == "true" ]]; then
+            {
+              echo "### ✅ Actions Completed"
+              echo "- 🏷️ Created git tag: \`$NEW_VERSION\`"
+              echo "- 📦 Created GitHub release"
+              echo ""
+              echo "### 🔄 Next Steps"
+              echo "- \`docker-publish.yml\` should build & push using the new tag"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### ℹ️ No Action Required"
+              echo "Version \`$NEW_VERSION\` already exists."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/weekly-security-report.yml
+++ b/.github/workflows/weekly-security-report.yml
@@ -1,0 +1,416 @@
+# ============================================================================
+# 🛡️ Weekly Security Report
+# ============================================================================
+# Single weekly digest covering BOTH vulnerabilities AND outdated dependencies.
+#
+# DESIGN INTENT
+# -------------
+# A developer should be able to open ONE issue per Monday and know everything
+# that needs attention this week — no need to babysit per-PR Dependabot noise.
+#
+#   • Python: Safety CLI (preferred, richer DB) → fallback to pip-audit if
+#             SAFETY_API_KEY is not configured on the repo.
+#   • Node:   npm audit (no API key needed).
+#   • Outdated: pip list --outdated + npm outdated, surfaced inline.
+#   • Issue opens whenever vulns > 0 OR outdated > 0 (the whole point).
+#   • Updates the existing weekly issue in place — no inbox flood.
+#   • Auto-closes the previous week's issue when the new scan is fully clean.
+#   • Assigns @MaBoNi, labels security/automated/maintenance, sets Type: Task.
+#
+# REQUIREMENTS
+# ------------
+# Repo or org-level secret SAFETY_API_KEY (optional — falls back to pip-audit).
+# Labels `security`, `automated`, `maintenance` must exist on the repo BEFORE
+# the first run (workflow soft-fails on labels but the issue won't get them).
+# ============================================================================
+
+name: 🛡️ Weekly Security Report
+
+on:
+  schedule:
+    # Mondays 09:00 UTC = 10:00 CET / 11:00 CEST
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  scan:
+    name: 🔍 Vulnerability & freshness scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # ── Detect Python projects ──────────────────────────────────────────
+      - name: Detect Python project
+        id: detect-py
+        run: |
+          if find . -maxdepth 3 \( -name "requirements*.txt" -o -name "pyproject.toml" \) \
+               -not -path "./node_modules/*" -not -path "./.venv/*" -print -quit | grep -q .; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Python
+        if: steps.detect-py.outputs.present == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install Python audit tooling
+        if: steps.detect-py.outputs.present == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install safety pip-audit
+
+      # ── Python vulnerability scan (Safety preferred, pip-audit fallback)
+      - name: Python vulnerability scan
+        if: steps.detect-py.outputs.present == 'true'
+        id: py-vulns
+        env:
+          SAFETY_API_KEY: ${{ secrets.SAFETY_API_KEY }}
+        run: |
+          mkdir -p .audit
+          : > .audit/python_findings.json
+
+          if [ -n "$SAFETY_API_KEY" ]; then
+            scanner="safety"
+            echo "Using Safety CLI"
+          else
+            scanner="pip-audit"
+            echo "SAFETY_API_KEY not set — falling back to pip-audit"
+          fi
+          echo "scanner=$scanner" >> "$GITHUB_OUTPUT"
+
+          total=0
+          paths=()
+          while IFS= read -r req; do
+            paths+=("$req")
+          done < <(find . -maxdepth 3 -name "requirements*.txt" -not -path "./node_modules/*" -not -path "./.venv/*")
+          while IFS= read -r pyp; do
+            paths+=("$(dirname "$pyp")")
+          done < <(find . -maxdepth 3 -name "pyproject.toml" -not -path "./node_modules/*" -not -path "./.venv/*")
+
+          for p in "${paths[@]}"; do
+            slug=$(echo "$p" | tr '/.' '__')
+            out=".audit/py_${slug}.json"
+            echo "::group::scan $p"
+            if [ "$scanner" = "safety" ]; then
+              if [ -f "$p" ]; then
+                target="$(dirname "$p")"
+              else
+                target="$p"
+              fi
+              # Tell Safety this is the *repo* — without this it derives the
+              # project name from the target directory, which makes scans of
+              # backend/, api/, etc. report as those generic folder names on
+              # the Safety platform instead of the actual repo.
+              repo_name="${GITHUB_REPOSITORY##*/}"
+              printf '[project]\nid = %s\nname = %s\n' "$repo_name" "$repo_name" > "$target/.safety-project.ini"
+              safety scan --target "$target" --output json > "$out" 2>/dev/null || true
+              rm -f "$target/.safety-project.ini"
+              n=$(jq '[(.scan_results.projects // [])[]?.files[]?.results.dependencies[]?.vulnerabilities[]?] | length' "$out" 2>/dev/null)
+              n="${n:-0}"
+            else
+              if [ -f "$p" ]; then
+                pip-audit --requirement "$p" --format json --output "$out" || true
+              else
+                (cd "$p" && pip-audit --format json --output "/tmp/${slug}.json") || true
+                cp "/tmp/${slug}.json" "$out" 2>/dev/null || true
+              fi
+              n=$(jq '[(.dependencies // [])[]? | (.vulns // [])[]?] | length' "$out" 2>/dev/null)
+              n="${n:-0}"
+            fi
+            echo "  $p: $n vulns"
+            total=$((total + n))
+            echo "::endgroup::"
+          done
+          echo "vuln_count=$total" >> "$GITHUB_OUTPUT"
+
+      # ── Python outdated check ───────────────────────────────────────────
+      - name: Python outdated packages
+        if: steps.detect-py.outputs.present == 'true'
+        id: py-outdated
+        run: |
+          mkdir -p .audit
+          : > .audit/py_outdated.json
+          total=0
+          while IFS= read -r req; do
+            slug=$(echo "$req" | tr '/.' '__')
+            venv="/tmp/venv_${slug}"
+            python -m venv "$venv" >/dev/null 2>&1
+            # shellcheck disable=SC1090
+            source "$venv/bin/activate"
+            pip install --quiet --upgrade pip >/dev/null 2>&1
+            pip install --quiet -r "$req" >/dev/null 2>&1 || true
+            out=$(pip list --outdated --format json 2>/dev/null || echo "[]")
+            echo "$out" > ".audit/py_outdated_${slug}.json"
+            n=$(echo "$out" | jq 'length' 2>/dev/null)
+            n="${n:-0}"
+            echo "  $req: $n outdated"
+            total=$((total + n))
+            deactivate
+          done < <(find . -maxdepth 3 -name "requirements*.txt" -not -path "./node_modules/*" -not -path "./.venv/*")
+          echo "outdated_count=$total" >> "$GITHUB_OUTPUT"
+
+      # ── Node detect ─────────────────────────────────────────────────────
+      - name: Detect Node project(s)
+        id: detect-node
+        run: |
+          mapfile -t pkgs < <(find . -maxdepth 3 -name "package.json" -not -path "*/node_modules/*")
+          if [ "${#pkgs[@]}" -gt 0 ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            printf '%s\n' "${pkgs[@]}" > .npm-projects.txt
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node
+        if: steps.detect-node.outputs.present == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+
+      # ── Node vulnerability + outdated scan ──────────────────────────────
+      - name: Node audit & outdated
+        if: steps.detect-node.outputs.present == 'true'
+        id: node
+        run: |
+          mkdir -p .audit
+          vulns_total=0
+          outdated_total=0
+          while IFS= read -r pkg; do
+            dir=$(dirname "$pkg")
+            slug=$(echo "$dir" | tr '/.' '__')
+            echo "::group::npm install + audit + outdated ($dir)"
+            (cd "$dir" && npm install --ignore-scripts --no-audit --no-fund --silent) || true
+
+            audit_out=$( (cd "$dir" && npm audit --omit=dev --audit-level=low --json) 2>/dev/null || true )
+            echo "$audit_out" > ".audit/node_audit_${slug}.json"
+            if [ -n "$audit_out" ]; then
+              n=$(echo "$audit_out" | jq '(.metadata.vulnerabilities // {}) | [.info, .low, .moderate, .high, .critical] | map(. // 0) | add' 2>/dev/null)
+            fi
+            n="${n:-0}"
+            echo "  $dir vulns: $n"
+            vulns_total=$((vulns_total + n))
+
+            outdated_out=$( (cd "$dir" && npm outdated --json) 2>/dev/null || true )
+            echo "$outdated_out" > ".audit/node_outdated_${slug}.json"
+            if [ -n "$outdated_out" ]; then
+              m=$(echo "$outdated_out" | jq 'length' 2>/dev/null)
+            fi
+            m="${m:-0}"
+            echo "  $dir outdated: $m"
+            outdated_total=$((outdated_total + m))
+            echo "::endgroup::"
+          done < .npm-projects.txt
+          echo "vuln_count=$vulns_total" >> "$GITHUB_OUTPUT"
+          echo "outdated_count=$outdated_total" >> "$GITHUB_OUTPUT"
+
+      # ── Aggregate totals ────────────────────────────────────────────────
+      - name: Compute totals
+        id: totals
+        run: |
+          py_v="${{ steps.py-vulns.outputs.vuln_count || 0 }}"
+          py_o="${{ steps.py-outdated.outputs.outdated_count || 0 }}"
+          n_v="${{ steps.node.outputs.vuln_count || 0 }}"
+          n_o="${{ steps.node.outputs.outdated_count || 0 }}"
+          scanner="${{ steps.py-vulns.outputs.scanner || 'n/a' }}"
+          vulns=$((py_v + n_v))
+          outdated=$((py_o + n_o))
+          {
+            echo "py_vulns=$py_v"
+            echo "py_outdated=$py_o"
+            echo "node_vulns=$n_v"
+            echo "node_outdated=$n_o"
+            echo "py_scanner=$scanner"
+            echo "vulns=$vulns"
+            echo "outdated=$outdated"
+          } >> "$GITHUB_OUTPUT"
+          echo "📊 Vulnerabilities: $vulns (py=$py_v, node=$n_v)"
+          echo "📊 Outdated:        $outdated (py=$py_o, node=$n_o)"
+
+      # ── Build report body when there's anything to report ───────────────
+      - name: Build report body
+        if: steps.totals.outputs.vulns != '0' || steps.totals.outputs.outdated != '0'
+        id: body
+        run: |
+          {
+            echo 'body<<EOF_BODY'
+            echo "## 🛡️ Weekly Security Report"
+            echo ""
+            echo "**Date**: $(date +%Y-%m-%d)"
+            echo "**Workflow run**: [#${GITHUB_RUN_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
+            echo "**Python scanner**: ${{ steps.totals.outputs.py_scanner }}"
+            echo ""
+            echo "### 📊 Summary"
+            echo ""
+            echo "| Stack | Vulnerabilities | Outdated |"
+            echo "|---|---:|---:|"
+            echo "| Python | ${{ steps.totals.outputs.py_vulns }} | ${{ steps.totals.outputs.py_outdated }} |"
+            echo "| Node (prod-vulns / all-outdated) | ${{ steps.totals.outputs.node_vulns }} | ${{ steps.totals.outputs.node_outdated }} |"
+            echo "| **Total** | **${{ steps.totals.outputs.vulns }}** | **${{ steps.totals.outputs.outdated }}** |"
+            echo ""
+            if [ "${{ steps.totals.outputs.vulns }}" != "0" ]; then
+              echo "### 🚨 Vulnerabilities"
+              echo ""
+              echo "<details><summary>Python (raw JSON from ${{ steps.totals.outputs.py_scanner }})</summary>"
+              echo ""
+              echo '```json'
+              if [ "${{ steps.totals.outputs.py_scanner }}" = "safety" ]; then
+                jq -s '[.[] | (.scan_results.projects // [])[]?.files[]?.results.dependencies[]? | select((.vulnerabilities // []) | length > 0)]' .audit/py_*.json 2>/dev/null | head -300 || echo "(no python findings parsed)"
+              else
+                jq -s '[.[] | (.dependencies // [])[]? | select((.vulns // []) | length > 0)]' .audit/py_*.json 2>/dev/null | head -300 || echo "(no python findings parsed)"
+              fi
+              echo '```'
+              echo "</details>"
+              echo ""
+              echo "<details><summary>Node (npm audit JSON, prod-only)</summary>"
+              echo ""
+              echo '```json'
+              jq -s '[.[] | (.vulnerabilities // {}) | to_entries[] | select(.value.severity != "info")]' .audit/node_audit_*.json 2>/dev/null | head -300 || echo "(no node findings)"
+              echo '```'
+              echo "</details>"
+              echo ""
+            fi
+            if [ "${{ steps.totals.outputs.outdated }}" != "0" ]; then
+              echo "### 📦 Outdated dependencies"
+              echo ""
+              for f in .audit/py_outdated_*.json; do
+                [ -f "$f" ] || continue
+                [ "$(jq 'length' "$f" 2>/dev/null)" = "0" ] && continue
+                label=$(basename "$f" .json | sed 's/py_outdated_//' | tr '_' '/')
+                echo "**Python — $label**"
+                echo ""
+                echo "| Package | Current | Latest | Type |"
+                echo "|---|---|---|---|"
+                jq -r '.[] | "| \(.name) | \(.version) | \(.latest_version // .latest) | \(.latest_filetype // "wheel") |"' "$f" 2>/dev/null
+                echo ""
+              done
+              for f in .audit/node_outdated_*.json; do
+                [ -f "$f" ] || continue
+                content=$(cat "$f")
+                [ -z "$content" ] || [ "$content" = "{}" ] && continue
+                label=$(basename "$f" .json | sed 's/node_outdated_//' | tr '_' '/')
+                echo "**Node — $label**"
+                echo ""
+                echo "| Package | Current | Wanted | Latest |"
+                echo "|---|---|---|---|"
+                echo "$content" | jq -r 'to_entries[] | "| \(.key) | \(.value.current // "—") | \(.value.wanted // "—") | \(.value.latest // "—") |"' 2>/dev/null
+                echo ""
+              done
+            fi
+            echo "### 🛠️ Suggested fixes"
+            echo ""
+            echo "- **Python**: \`safety scan --apply-updates\` (or \`pip-audit --fix\`); for pinned files bump the version and re-run."
+            echo "- **Node**: \`npm audit fix\` for non-breaking; \`npm update\` for outdated; \`npx npm-check-updates -u\` for major bumps."
+            echo "- Review breaking changes carefully — outdated ≠ broken."
+            echo ""
+            echo "---"
+            echo "_Automated by \`.github/workflows/weekly-security-report.yml\`. Next run: Monday 09:00 UTC._"
+            echo EOF_BODY
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find existing open report
+        id: find
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { data } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security,automated',
+              per_page: 50,
+            });
+            const existing = data.find(i => i.title.startsWith('🛡️ Weekly Security Report'));
+            core.setOutput('existing_number', existing ? existing.number : '');
+
+      - name: Create or update issue (findings present)
+        if: steps.totals.outputs.vulns != '0' || steps.totals.outputs.outdated != '0'
+        uses: actions/github-script@v9
+        env:
+          BODY: ${{ steps.body.outputs.body }}
+          EXISTING: ${{ steps.find.outputs.existing_number }}
+        with:
+          script: |
+            const title = `🛡️ Weekly Security Report - ${new Date().toISOString().slice(0,10)}`;
+            const body  = process.env.BODY;
+            const labels = ['security', 'automated', 'maintenance'];
+            const assignees = ['MaBoNi'];
+
+            if (process.env.EXISTING) {
+              const num = parseInt(process.env.EXISTING, 10);
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: num,
+                title, body,
+              });
+              core.notice(`Updated existing report #${num}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title, body, labels, assignees,
+              });
+              core.notice(`Created report #${created.data.number}`);
+
+              // Best-effort: tag with org-wide "Task" issue type via GraphQL.
+              try {
+                const issueId = created.data.node_id;
+                const types = await github.graphql(`
+                  query($org: String!) {
+                    organization(login: $org) {
+                      issueTypes(first: 20) { nodes { id name } }
+                    }
+                  }
+                `, { org: context.repo.owner });
+                const task = types.organization.issueTypes.nodes.find(t => t.name === 'Task');
+                if (task) {
+                  await github.graphql(`
+                    mutation($issueId: ID!, $typeId: ID!) {
+                      updateIssueIssueType(input: { issueId: $issueId, issueTypeId: $typeId }) {
+                        issue { id }
+                      }
+                    }
+                  `, { issueId, typeId: task.id });
+                  core.notice('Tagged issue as Type: Task');
+                }
+              } catch (e) {
+                core.warning(`Could not set issue type: ${e.message}`);
+              }
+            }
+
+      - name: Close stale clean-week report
+        if: steps.totals.outputs.vulns == '0' && steps.totals.outputs.outdated == '0' && steps.find.outputs.existing_number != ''
+        uses: actions/github-script@v9
+        env:
+          EXISTING: ${{ steps.find.outputs.existing_number }}
+        with:
+          script: |
+            const num = parseInt(process.env.EXISTING, 10);
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: num,
+              body: `✅ This week's scan is clean (0 vulnerabilities, 0 outdated). Auto-closing — next run on Monday 09:00 UTC.`,
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: num,
+              state: 'closed',
+              state_reason: 'completed',
+            });
+            core.notice(`Auto-closed clean-week report #${num}`);
+
+      - name: All clear
+        if: steps.totals.outputs.vulns == '0' && steps.totals.outputs.outdated == '0'
+        run: |
+          echo "✅ No vulnerabilities and no outdated dependencies."

--- a/scripts/increment-version.sh
+++ b/scripts/increment-version.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# === scripts/increment-version.sh ===
+# Automatically increment patch version for semantic versioning (YY.MM.PATCH)
+# Used by GitHub Actions on PR merge to main branch
+
+set -euo pipefail
+
+# Configuration
+readonly CURRENT_YEAR=$(date +%y)
+readonly CURRENT_MONTH=$(date +%-m)
+
+# Function to get the current month version (e.g., 26.4)
+get_current_month_version() {
+    echo "${CURRENT_YEAR}.${CURRENT_MONTH}"
+}
+
+# Function to get the latest git tag matching the current month
+get_latest_patch_version() {
+    local month_prefix="$1"
+
+    # Get all tags matching the current month pattern (e.g., 26.4.*)
+    # Sort them by version number and get the latest one
+    local latest_tag
+    latest_tag=$(git tag -l "${month_prefix}.*" | sort -V | tail -n 1)
+
+    if [[ -z "$latest_tag" ]]; then
+        # No patch versions exist for this month, start with .0
+        echo "${month_prefix}.0"
+    else
+        echo "$latest_tag"
+    fi
+}
+
+# Function to increment the patch version
+increment_patch() {
+    local version="$1"
+
+    # Extract patch number from version (e.g., "26.4.15" -> "15")
+    local patch_number
+    patch_number=$(echo "$version" | cut -d. -f3)
+
+    # Increment patch number
+    local new_patch=$((patch_number + 1))
+
+    # Reconstruct version with incremented patch
+    local month_version
+    month_version=$(echo "$version" | cut -d. -f1-2)
+
+    echo "${month_version}.${new_patch}"
+}
+
+# Main logic
+main() {
+    echo "🔧 Calculating next patch version..."
+
+    # Get current month version prefix
+    local month_version
+    month_version=$(get_current_month_version)
+    echo "📅 Current month version prefix: $month_version"
+
+    # Get latest patch version for current month
+    local current_version
+    current_version=$(get_latest_patch_version "$month_version")
+    echo "🏷️  Latest version: $current_version"
+
+    # Check if we need to roll to new month
+    local current_month_from_tag
+    current_month_from_tag=$(echo "$current_version" | cut -d. -f2)
+
+    if [[ "$current_month_from_tag" != "$CURRENT_MONTH" ]]; then
+        # New month, start from .0
+        local new_version="${month_version}.0"
+        echo "🆕 New month detected, starting with: $new_version"
+    else
+        # Same month, increment patch
+        local new_version
+        new_version=$(increment_patch "$current_version")
+        echo "⬆️  Incremented to: $new_version"
+    fi
+
+    # Output the new version for GitHub Actions (if available)
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        echo "NEW_VERSION=$new_version" >> "$GITHUB_OUTPUT"
+        echo "PREVIOUS_VERSION=$current_version" >> "$GITHUB_OUTPUT"
+    fi
+
+    # Also output to stdout for local usage
+    echo "📦 New version: $new_version"
+    echo "$new_version"
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
## Adopt org-wide automation: weekly security digest, surgical Dependabot, YY.MM.PATCH versioning

This brings `homeassistant-tracker` onto the same posture as the BondIT-ApS org repos — three coordinated changes in one PR.

### 1. 🛡️ Weekly security digest
- ➕ `.github/workflows/weekly-security-report.yml`
- Mondays 09:00 UTC. Auto-detects Python (`backend/requirements.txt`) and Node (none here yet — graceful no-op).
- One digest issue per week with both **vulnerabilities** AND **outdated packages**. Updates the issue in place; auto-closes on clean weeks.

### 2. 🔧 Dependabot — surgical security-only mode
- 🔄 `.github/dependabot.yml` rewritten
- **Gap caught**: previous config had `docker` + `github-actions` only. **Python `pip` ecosystem was missing entirely**, so `backend/requirements.txt` wasn't being scanned by Dependabot at all. Now added.
- `open-pull-requests-limit: 0` on every ecosystem:
  - **version-updates OFF** — the noise. Digest is the source of truth.
  - **security-updates STILL ON** — CVE response remains same-day. Controlled by repo Settings → Code security toggle (stays ON).

### 3. 📦 YY.MM.PATCH versioning (matches BondIT repos)
- ➕ `scripts/increment-version.sh` — ported from `vehicledb-frontend`
- ➕ `.github/workflows/version-increment.yml`
- On push to `main`:
  1. `detect-changes` — only fire on `backend/` or `frontend/` source changes (skip doc/CI/dependabot-only pushes)
  2. Calculate next tag: `YY.MM.N`. Patch resets on first push of a new calendar month.
  3. Create + push the git tag, create GitHub release.
- Docker builds stay on the existing `docker-publish.yml` — this PR doesn't touch that flow.

### Verify after merge
1. Actions → 🛡️ Weekly Security Report → **Run workflow** to see the first digest (will likely surface outdated Python deps in `backend/requirements.txt` — none of those have been tracked before!)
2. Next source-changes merge to `main` will produce a `26.6.0` tag + matching release.

### Notes
- New labels `automated` and `maintenance` created on the repo (existing `security`, `dependencies`, `python`, `docker`, `github_actions` already in place).
- This PR itself is CI/config-only — the `detect-changes` job in the new version-increment workflow correctly excludes paths under `.github/` so this very merge won't create a tag. Next source-touching merge will.

### Reference shape
- `BondIT-ApS/vehicledb-backend#65` — first digest rollout
- `BondIT-ApS/vehicledb-frontend` (`scripts/increment-version.sh`) — versioning reference
