### PR TITLE
fix(deps): apply weekly security digest #92 — safe minor bumps

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,8 +1,8 @@
 Flask==3.1.3
-Flask-Cors==6.0.0
+Flask-Cors==6.0.2
 Flask-Limiter==3.8.0
-SQLAlchemy==2.0.36
-requests==2.33.0
-psycopg2-binary==2.9.10
-APScheduler==3.7.0
-Werkzeug==3.1.6
+SQLAlchemy==2.0.50
+requests==2.34.2
+psycopg2-binary==2.9.12
+APScheduler==3.11.2
+Werkzeug==3.1.8


### PR DESCRIPTION
## Apply weekly security digest #92 — safe minors

Resolves the actionable items from the first weekly security digest run on this repo.

### Applied — `backend/requirements.txt` direct pins

| Package | From | To |
|---|---|---|
| `Flask-Cors` | 6.0.0 | 6.0.2 |
| `SQLAlchemy` | 2.0.36 | 2.0.50 |
| `requests` | 2.33.0 | 2.34.2 |
| `psycopg2-binary` | 2.9.10 | 2.9.12 |
| `APScheduler` | 3.7.0 | 3.11.2 |
| `Werkzeug` | 3.1.6 | 3.1.8 |

`APScheduler` skipped a lot of releases (3.7 → 3.11), but it's still on the 3.x line — no documented breaking changes for in-process scheduling, only added features and bug fixes. Worth a quick smoke test in dev.

### Deferred (tracked separately)

| Package | From | To | Reason to defer |
|---|---|---|---|
| `Flask-Limiter` | 3.8.0 | 4.1.1 | 4.0 changed the storage backend API |
| `rich` | 13.9.4 | 15.0.0 | 15 drops Python 3.8 support among other breaks |
| `tzlocal` | 2.1 | 5.3.1 | v3 pivoted from `pytz` to stdlib `zoneinfo` — likely real code change wherever TZ is handled |

Note: `rich` and `tzlocal` are **transitive** (not directly pinned in `requirements.txt`), so even on the eventual major migration they'd ride along with whichever parent package bumps them.

### Verification

- `pip install --dry-run` resolver clean against the new pin set
- This PR touches `backend/`, so the new `version-increment.yml` workflow will run on merge and produce the first `26.6.0` tag — meta-validation of the versioning rollout from #91

Closes #92
