### PR TITLE
fix(deps): migrate Flask-Limiter 3.8.0 → 4.1.1 (major)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 Flask==3.1.3
 Flask-Cors==6.0.2
-Flask-Limiter==3.8.0
+Flask-Limiter==4.1.1
 SQLAlchemy==2.0.50
 requests==2.34.2
 psycopg2-binary==2.9.12


### PR DESCRIPTION
## Major: Flask-Limiter 3.8.0 → 4.1.1

Last directly-pinned major from digest issue #92.

### Verified zero code changes needed

The v4 changelog flags one breaking change:
> Prefix all internal sub modules with underscore. All imports should be from the root `flask_limiter` namespace only.

In practice this only renamed the *truly internal* helpers. The public submodules that this repo imports from — `flask_limiter` and `flask_limiter.util` — are **still public in 4.1.1**:

```python
# backend/app.py — both imports work unchanged on v4
from flask_limiter import Limiter
from flask_limiter.util import get_remote_address
```

### Repo's usage surface

Single instantiation at `backend/app.py:46-52`:
```python
limiter = Limiter(
    app=app,
    key_func=get_remote_address,
    default_limits=["200 per day", "50 per hour"],
    storage_uri="memory://",
    strategy="fixed-window",
)
```

All kwargs are still accepted by the v4 constructor. In v4 `key_func` is the only positional-or-keyword parameter and everything else is keyword-only — but the code already passes everything as kwargs, so no change required.

No `@limiter.limit(...)` decorators or `limiter.exempt` calls exist anywhere in the API blueprints, so the route-level rate-limit API surface (which sees more 4.x churn) isn't touched at all.

### Verification

| Check | Result |
|---|---|
| `pip install -r backend/requirements.txt` resolves | ✅ |
| `python -c "import app"` (with stubbed env) | ✅ imports cleanly |
| `type(app.limiter)` | `flask_limiter._extension.Limiter` (v4 class) ✅ |
| `flask_limiter.util.get_remote_address` still public | ✅ |
| `Limiter` constructor signature inspected | ✅ all 5 kwargs the repo uses are accepted |

### Out of scope — transitive, not directly pinned

These appeared as "outdated" in digest #92 but live in `pip freeze`, not `requirements.txt`. They'll ride along on whichever parent package eventually bumps them:

- `rich` 13.9 → 15.0 (transitive, likely via `safety` or `flask`)
- `tzlocal` 2.1 → 5.3 (transitive, likely via `APScheduler`)

Refs #92
