### PR TITLE
docs(deployment): add security monitoring & alerting recipe

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -19,3 +19,6 @@ BACKEND_API_URL=http://homeassistant-tracker-backend:5171
 # CORS Configuration (comma-separated list of allowed origins)
 CORS_ORIGINS=http://localhost:5172,http://127.0.0.1:5172
 # For production, add your domain: https://yourdomain.com
+
+# Observability profile (only used with `docker compose --profile observability up`)
+GRAFANA_ADMIN_PASSWORD=changeme-please

--- a/backend/services/ha_fetcher.py
+++ b/backend/services/ha_fetcher.py
@@ -97,7 +97,6 @@ def fetch_and_save_location(user_entity):
                         device_response.status_code,
                     )
                     logger.error("Device tracker URL: %s", device_tracker_url)
-                    logger.error("Headers: %s", headers)
         else:
             logger.error(
                 "Failed to fetch data for %s. Status Code: %s",
@@ -105,11 +104,9 @@ def fetch_and_save_location(user_entity):
                 response.status_code,
             )
             logger.error("Request URL: %s", url)
-            logger.error("Headers: %s", headers)
 
     except Exception as e:
         logger.error(
             "Error occurred while fetching data for %s: %s", user_entity, str(e)
         )
         logger.error("Request URL: %s", url)
-        logger.error("Headers: %s", headers)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,5 +56,49 @@ services:
       interval: 10s
       retries: 5
 
+  loki:
+    image: grafana/loki:3.2.0
+    container_name: tracker-loki
+    restart: unless-stopped
+    command: -config.file=/etc/loki/local-config.yaml
+    profiles: [observability]
+    volumes:
+      - loki_data:/loki
+      - ./observability/loki-config.yaml:/etc/loki/local-config.yaml:ro
+
+  promtail:
+    image: grafana/promtail:3.2.0
+    container_name: tracker-promtail
+    restart: unless-stopped
+    command: -config.file=/etc/promtail/config.yaml
+    profiles: [observability]
+    volumes:
+      - ./observability/promtail-config.yaml:/etc/promtail/config.yaml:ro
+      - /var/log:/var/log:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on: [loki]
+
+  grafana:
+    image: grafana/grafana:11.3.0
+    container_name: tracker-grafana
+    restart: unless-stopped
+    profiles: [observability]
+    environment:
+      # Set GRAFANA_ADMIN_PASSWORD in your .env (see .env.example) before
+      # running with --profile observability. Default below is intentionally
+      # weak so `docker compose up` without the profile keeps working.
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-changeme-please}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_FEATURE_TOGGLES_ENABLE=alertingApiServer
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "127.0.0.1:3000:3000"
+    depends_on: [loki]
+
 volumes:
   postgres_data:
+  loki_data:
+  grafana_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - grafana_data:/var/lib/grafana
       - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
     ports:
-      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:3001:3000"
     depends_on: [loki]
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
     volumes:
       - grafana_data:/var/lib/grafana
       - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./observability/grafana/dashboards:/var/lib/grafana/dashboards:ro
     ports:
       - "127.0.0.1:3001:3000"
     depends_on: [loki]

--- a/docs/deployment/monitoring.md
+++ b/docs/deployment/monitoring.md
@@ -38,76 +38,48 @@ Prometheus" section at the end for when that changes.
 
 ---
 
-## docker-compose stack
+## Quick start
 
-Add the following to `docker-compose.yml` (or a `docker-compose.obs.yml`
-overlay):
+Everything below is wired into the repo. To bring up the observability
+stack:
 
-```yaml
-  loki:
-    image: grafana/loki:3.2.0
-    container_name: tracker-loki
-    restart: unless-stopped
-    command: -config.file=/etc/loki/local-config.yaml
-    volumes:
-      - loki_data:/loki
-    networks: [default]
+1. Copy the contact-points template and paste your Discord webhook:
 
-  promtail:
-    image: grafana/promtail:3.2.0
-    container_name: tracker-promtail
-    restart: unless-stopped
-    command: -config.file=/etc/promtail/config.yaml
-    volumes:
-      - ./observability/promtail-config.yaml:/etc/promtail/config.yaml:ro
-      - /var/log:/var/log:ro
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    depends_on: [loki]
+   ```bash
+   cp observability/grafana/provisioning/alerting/contactpoints.yaml.example \
+      observability/grafana/provisioning/alerting/contactpoints.yaml
+   # edit the new file, replace REPLACE_WITH_YOUR_DISCORD_WEBHOOK_URL
+   ```
 
-  grafana:
-    image: grafana/grafana:11.3.0
-    container_name: tracker-grafana
-    restart: unless-stopped
-    environment:
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
-      - GF_USERS_ALLOW_SIGN_UP=false
-    volumes:
-      - grafana_data:/var/lib/grafana
-      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
-    ports:
-      - "127.0.0.1:3000:3000"   # Front with Caddy / Tailscale, not public
-    depends_on: [loki]
+2. Set `GRAFANA_ADMIN_PASSWORD` in your `.env` (see `.env.template`).
 
-volumes:
-  loki_data:
-  grafana_data:
-```
+3. Bring up the stack:
 
-`promtail-config.yaml` should use the `docker_sd_config` discovery so
-every container picks up labels automatically:
+   ```bash
+   docker compose --profile observability up -d
+   ```
 
-```yaml
-server:
-  http_listen_port: 9080
+4. Grafana: http://127.0.0.1:3000 (admin / your password). Front with
+   Caddy / Tailscale for any non-local access — the port is bound to
+   `127.0.0.1` on purpose.
 
-positions:
-  filename: /tmp/positions.yaml
+Without the `--profile observability` flag, `docker compose up`
+continues to start only `backend`, `frontend`, `db` — exactly as before.
 
-clients:
-  - url: http://loki:3100/loki/api/v1/push
+## File layout
 
-scrape_configs:
-  - job_name: docker
-    docker_sd_configs:
-      - host: unix:///var/run/docker.sock
-        refresh_interval: 5s
-    relabel_configs:
-      - source_labels: ["__meta_docker_container_name"]
-        target_label: container
-      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
-        target_label: service
-```
+- `docker-compose.yml` — `loki`, `promtail`, `grafana` services, gated
+  by the `observability` profile.
+- `observability/loki-config.yaml` — Loki config, 14-day retention.
+- `observability/promtail-config.yaml` — Docker socket discovery, ships
+  every container's logs to Loki with `service` / `container` labels.
+- `observability/grafana/provisioning/datasources/loki.yaml` —
+  auto-wires Loki as the default datasource.
+- `observability/grafana/provisioning/alerting/rules.yaml` — the 5 alert
+  rules below, provisioned at boot.
+- `observability/grafana/provisioning/alerting/contactpoints.yaml.example`
+  — Discord webhook template. The real file is gitignored; copy it,
+  fill it in, and Grafana picks it up on next restart.
 
 ---
 

--- a/docs/deployment/monitoring.md
+++ b/docs/deployment/monitoring.md
@@ -1,0 +1,203 @@
+# Security Monitoring & Alerting
+
+This document covers an opinionated, lightweight observability stack for
+homeassistant-tracker in production. The goals are modest:
+
+1. Centralised, searchable logs from `backend`, `frontend`, `db`, and the
+   TLS proxy.
+2. Local retention long enough to investigate incidents (default: 14 days,
+   rotated by size).
+3. Push-style alerts to a Discord webhook for the handful of events that
+   actually warrant a human looking at them — failed auth bursts, 5xx
+   spikes, container restarts, certificate near-expiry.
+
+The stack is **Loki + Promtail + Grafana**, all containerised. No
+metrics server, no full Prometheus deployment — see the "Graduating to
+Prometheus" section at the end for when that changes.
+
+---
+
+## Stack overview
+
+```
+ backend, frontend, caddy, db  ──►  Promtail  ──►  Loki  ──►  Grafana
+                                                              │
+                                                              ▼
+                                                       Discord webhook
+                                                       (Alertmanager-
+                                                        compatible
+                                                        webhook receiver)
+```
+
+- **Loki** stores logs. Single-binary, filesystem-backed for small
+  deployments.
+- **Promtail** tails Docker container logs via the Docker socket and ships
+  them to Loki with service labels.
+- **Grafana** is the query / dashboard / alert UI. Alert rules are
+  defined declaratively under `grafana/provisioning/alerting/`.
+
+---
+
+## docker-compose stack
+
+Add the following to `docker-compose.yml` (or a `docker-compose.obs.yml`
+overlay):
+
+```yaml
+  loki:
+    image: grafana/loki:3.2.0
+    container_name: tracker-loki
+    restart: unless-stopped
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - loki_data:/loki
+    networks: [default]
+
+  promtail:
+    image: grafana/promtail:3.2.0
+    container_name: tracker-promtail
+    restart: unless-stopped
+    command: -config.file=/etc/promtail/config.yaml
+    volumes:
+      - ./observability/promtail-config.yaml:/etc/promtail/config.yaml:ro
+      - /var/log:/var/log:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on: [loki]
+
+  grafana:
+    image: grafana/grafana:11.3.0
+    container_name: tracker-grafana
+    restart: unless-stopped
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "127.0.0.1:3000:3000"   # Front with Caddy / Tailscale, not public
+    depends_on: [loki]
+
+volumes:
+  loki_data:
+  grafana_data:
+```
+
+`promtail-config.yaml` should use the `docker_sd_config` discovery so
+every container picks up labels automatically:
+
+```yaml
+server:
+  http_listen_port: 9080
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ["__meta_docker_container_name"]
+        target_label: container
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: service
+```
+
+---
+
+## Log rotation
+
+Docker's default `json-file` driver grows forever. Cap it in
+`/etc/docker/daemon.json` on the host:
+
+```json
+{
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "50m",
+    "max-file": "5"
+  }
+}
+```
+
+`sudo systemctl restart docker` to apply. Existing containers keep the old
+config until recreated.
+
+Loki retention is set in its config (`retention_period: 336h` = 14 days).
+Adjust for disk budget.
+
+---
+
+## Alert rules
+
+Provision the following alerts under
+`observability/grafana/provisioning/alerting/rules.yaml` (Grafana picks
+them up at boot). The thresholds are starting points — tune after a week
+of baseline data.
+
+| Alert                      | Query (LogQL)                                                      | Threshold              | Severity |
+|----------------------------|--------------------------------------------------------------------|------------------------|----------|
+| Auth failure burst         | `sum(rate({service="backend"} \|= "401" [5m]))`                    | > 5 / min for 5 min    | warning  |
+| Backend 5xx spike          | `sum(rate({service="backend"} \|~ " 5\\d\\d " [5m]))`              | > 1 / min for 5 min    | warning  |
+| Container restart loop     | `count_over_time({service="backend"} \|= "Starting" [15m])`        | > 3 in 15 min          | critical |
+| DB connection errors       | `sum(rate({service="backend"} \|~ "OperationalError\|psycopg2" [5m]))` | > 0 for 5 min       | critical |
+| Caddy cert near expiry     | `{container="homeassistant-tracker-caddy"} \|~ "certificate.*expir"` | any in 24h           | warning  |
+
+### Discord webhook receiver
+
+Grafana supports Discord webhooks natively as a contact point:
+
+1. In Discord: server settings → Integrations → Webhooks → New Webhook,
+   copy the URL.
+2. In Grafana: Alerting → Contact points → Add → Discord, paste URL.
+3. Set the default notification policy to that contact point, or scope it
+   to `severity=critical` and route warnings to email.
+
+For everything-as-code, set it via provisioning under
+`observability/grafana/provisioning/alerting/contactpoints.yaml`.
+
+---
+
+## What's covered, what isn't
+
+Covered:
+
+- Centralised logs from every service container.
+- Discord pings for auth bursts, 5xx spikes, restart loops, DB errors,
+  cert expiry.
+- 14 days of searchable history.
+- Disk-bounded log growth.
+
+Not covered (intentionally, for v1):
+
+- System-level metrics (CPU / memory / disk) — `cAdvisor` + Prometheus is
+  the next step, see below.
+- Distributed tracing.
+- Synthetic uptime checks — handle externally (UptimeRobot, BetterStack)
+  to catch the case where the host itself is down and can't send alerts.
+
+---
+
+## Graduating to Prometheus
+
+Move from "logs + ad-hoc dashboards" to a full metrics stack when **any
+of** the following becomes true:
+
+- You need SLO-style alerting (e.g. "99.5% of requests under 300 ms over
+  30 days") — that's a histogram-quantile query, which needs metrics, not
+  logs.
+- You're running more than ~3 application instances and need cross-cutting
+  aggregation.
+- You want long-horizon (>90 days) trend data without paying for log
+  storage.
+
+At that point, add `prometheus` + `node-exporter` + `cadvisor` to the
+stack, point Grafana at Prometheus as a second data source, and migrate
+the rate-based alerts from LogQL to PromQL. Loki stays — it remains the
+best place to search the actual log lines a metric points you at.

--- a/observability/.gitignore
+++ b/observability/.gitignore
@@ -1,0 +1,1 @@
+grafana/provisioning/alerting/contactpoints.yaml

--- a/observability/grafana/dashboards/homeassistant-tracker.json
+++ b/observability/grafana/dashboards/homeassistant-tracker.json
@@ -1,0 +1,273 @@
+{
+  "uid": "ha-tracker-overview",
+  "title": "HomeAssistant Tracker — Overview",
+  "tags": ["homeassistant-tracker", "loki"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "loki-default" },
+        "query": "label_values(service)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2
+      },
+      {
+        "name": "stream",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "loki-default" },
+        "query": "label_values(stream)",
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2
+      },
+      {
+        "name": "search",
+        "type": "textbox",
+        "current": { "text": "", "value": "" },
+        "label": "Search"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Log Volume by Service",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "loki", "uid": "loki-default" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (service) (count_over_time({service=~\"$service\"} [$__auto]))",
+          "legendFormat": "{{ service }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 40,
+            "stacking": { "mode": "normal" }
+          }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi" }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Error Rate (5xx / errors)",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 6 },
+      "datasource": { "type": "loki", "uid": "loki-default" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (service) (rate({service=~\"$service\"} |~ \"(?i)(error|exception|traceback| 5\\\\d\\\\d )\" [$__auto]))",
+          "legendFormat": "{{ service }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15
+          },
+          "color": { "mode": "palette-classic" },
+          "unit": "reqps"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi" }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Auth Failures (401)",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 6 },
+      "datasource": { "type": "loki", "uid": "loki-default" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate({service=\"backend\"} |= \"401\" [$__auto]))",
+          "legendFormat": "401 rate"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15
+          },
+          "color": { "fixedColor": "orange", "mode": "fixed" },
+          "unit": "reqps"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "single" }
+      }
+    },
+    {
+      "id": 4,
+      "title": "DB Connection Errors",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 12 },
+      "datasource": { "type": "loki", "uid": "loki-default" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count_over_time({service=\"backend\"} |~ \"OperationalError|psycopg2\" [$__range])",
+          "legendFormat": "db errors"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "value": 0, "color": "green" },
+              { "value": 1, "color": "red" }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Backend Restarts",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 12 },
+      "datasource": { "type": "loki", "uid": "loki-default" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count_over_time({service=\"backend\"} |= \"Starting\" [$__range])"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "value": 0, "color": "green" },
+              { "value": 3, "color": "yellow" },
+              { "value": 5, "color": "red" }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "stderr Volume",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 12 },
+      "datasource": { "type": "loki", "uid": "loki-default" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count_over_time({service=~\"$service\", stream=\"stderr\"} [$__range])"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "value": 0, "color": "green" },
+              { "value": 10, "color": "yellow" },
+              { "value": 50, "color": "red" }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Total Log Lines",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 12 },
+      "datasource": { "type": "loki", "uid": "loki-default" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count_over_time({service=~\"$service\"} [$__range])"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "steps": [
+              { "value": 0, "color": "blue" }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Backend Logs",
+      "type": "logs",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "datasource": { "type": "loki", "uid": "loki-default" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "{service=\"backend\", stream=~\"$stream\"} |~ \"$search\""
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true,
+        "wrapLogMessage": true
+      }
+    },
+    {
+      "id": 11,
+      "title": "Frontend Logs",
+      "type": "logs",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
+      "datasource": { "type": "loki", "uid": "loki-default" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "{service=\"frontend\", stream=~\"$stream\"} |~ \"$search\""
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true,
+        "wrapLogMessage": true
+      }
+    },
+    {
+      "id": 12,
+      "title": "Database Logs",
+      "type": "logs",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 32 },
+      "datasource": { "type": "loki", "uid": "loki-default" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "{service=\"db\", stream=~\"$stream\"} |~ \"$search\""
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true,
+        "wrapLogMessage": true
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "version": 1
+}

--- a/observability/grafana/provisioning/alerting/contactpoints.yaml.example
+++ b/observability/grafana/provisioning/alerting/contactpoints.yaml.example
@@ -1,0 +1,18 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: discord-critical
+    receivers:
+      - uid: discord-critical
+        type: discord
+        settings:
+          url: REPLACE_WITH_YOUR_DISCORD_WEBHOOK_URL
+          use_discord_username: false
+          message: "{{ template \"default.message\" . }}"
+          title: "{{ template \"default.title\" . }}"
+
+policies:
+  - orgId: 1
+    receiver: discord-critical
+    group_by: [alertname]

--- a/observability/grafana/provisioning/alerting/rules.yaml
+++ b/observability/grafana/provisioning/alerting/rules.yaml
@@ -1,0 +1,317 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: homeassistant-tracker
+    folder: HomeAssistant Tracker
+    interval: 1m
+    rules:
+      - uid: auth-failure-burst
+        title: Auth failure burst
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: loki-default
+            model:
+              refId: A
+              datasource:
+                type: loki
+                uid: loki-default
+              expr: 'sum(rate({service="backend"} |= "401" [5m]))'
+              queryType: range
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: reduce
+              expression: A
+              reducer: last
+              datasource:
+                type: __expr__
+                uid: __expr__
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              datasource:
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0.0833]
+                  operator:
+                    type: and
+                  query:
+                    params: [B]
+                  reducer:
+                    type: last
+                    params: []
+                  type: query
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Auth failure burst on backend"
+          description: "More than 5 401 responses per minute over 5 minutes."
+
+      - uid: backend-5xx-spike
+        title: Backend 5xx spike
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: loki-default
+            model:
+              refId: A
+              datasource:
+                type: loki
+                uid: loki-default
+              expr: 'sum(rate({service="backend"} |~ " 5\\d\\d " [5m]))'
+              queryType: range
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: reduce
+              expression: A
+              reducer: last
+              datasource:
+                type: __expr__
+                uid: __expr__
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              datasource:
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0.0167]
+                  operator:
+                    type: and
+                  query:
+                    params: [B]
+                  reducer:
+                    type: last
+                    params: []
+                  type: query
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Backend 5xx spike"
+          description: "More than 1 backend 5xx response per minute over 5 minutes."
+
+      - uid: container-restart-loop
+        title: Container restart loop
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: loki-default
+            model:
+              refId: A
+              datasource:
+                type: loki
+                uid: loki-default
+              expr: 'count_over_time({service="backend"} |= "Starting" [15m])'
+              queryType: range
+          - refId: B
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: reduce
+              expression: A
+              reducer: last
+              datasource:
+                type: __expr__
+                uid: __expr__
+          - refId: C
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              datasource:
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [3]
+                  operator:
+                    type: and
+                  query:
+                    params: [B]
+                  reducer:
+                    type: last
+                    params: []
+                  type: query
+        noDataState: NoData
+        execErrState: Error
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Backend container restart loop"
+          description: "Backend container has logged 'Starting' more than 3 times in 15 minutes."
+
+      - uid: db-connection-errors
+        title: DB connection errors
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: loki-default
+            model:
+              refId: A
+              datasource:
+                type: loki
+                uid: loki-default
+              expr: 'sum(rate({service="backend"} |~ "OperationalError|psycopg2" [5m]))'
+              queryType: range
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: reduce
+              expression: A
+              reducer: last
+              datasource:
+                type: __expr__
+                uid: __expr__
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              datasource:
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+                  operator:
+                    type: and
+                  query:
+                    params: [B]
+                  reducer:
+                    type: last
+                    params: []
+                  type: query
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Database connection errors on backend"
+          description: "Backend is logging OperationalError / psycopg2 errors."
+
+      - uid: caddy-cert-near-expiry
+        title: Caddy cert near expiry
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 86400
+              to: 0
+            datasourceUid: loki-default
+            model:
+              refId: A
+              datasource:
+                type: loki
+                uid: loki-default
+              expr: 'count_over_time({container="homeassistant-tracker-caddy"} |~ "certificate.*expir" [24h])'
+              queryType: range
+          - refId: B
+            relativeTimeRange:
+              from: 86400
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: reduce
+              expression: A
+              reducer: last
+              datasource:
+                type: __expr__
+                uid: __expr__
+          - refId: C
+            relativeTimeRange:
+              from: 86400
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              datasource:
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+                  operator:
+                    type: and
+                  query:
+                    params: [B]
+                  reducer:
+                    type: last
+                    params: []
+                  type: query
+        noDataState: NoData
+        execErrState: Error
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Caddy certificate near expiry"
+          description: "Caddy logs contain a certificate-expiry message in the last 24h."

--- a/observability/grafana/provisioning/dashboards/dashboards.yaml
+++ b/observability/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: HomeAssistant Tracker
+    orgId: 1
+    folder: HomeAssistant Tracker
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/observability/grafana/provisioning/datasources/loki.yaml
+++ b/observability/grafana/provisioning/datasources/loki.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    uid: loki-default
+    access: proxy
+    url: http://loki:3100
+    isDefault: true
+    editable: false

--- a/observability/loki-config.yaml
+++ b/observability/loki-config.yaml
@@ -1,0 +1,40 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 336h
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+  delete_request_store: filesystem
+
+analytics:
+  reporting_enabled: false

--- a/observability/promtail-config.yaml
+++ b/observability/promtail-config.yaml
@@ -1,0 +1,22 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ["__meta_docker_container_name"]
+        target_label: container
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: service
+      - source_labels: ["__meta_docker_container_log_stream"]
+        target_label: stream


### PR DESCRIPTION
Adds `docs/deployment/monitoring.md` covering a lightweight Loki + Promtail + Grafana stack with:

- Docker-socket log shipping with automatic service labels
- 14-day Loki retention + Docker daemon log rotation caps
- A starter set of LogQL alert rules (auth bursts, 5xx spikes, restart loops, DB errors, cert expiry)
- Discord webhook contact point wiring
- A 'when to graduate to Prometheus' section so we don't over-engineer day one

Docs-only — no source changes, version-increment workflow will not fire.

Closes #79