### PR TITLE
fix(db): use explicit QueuePool config

### DIFF
--- a/backend/config/db.py
+++ b/backend/config/db.py
@@ -8,13 +8,22 @@ import logging
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
 from config.config import Config
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 Base = declarative_base()
-engine = create_engine(Config.SQLALCHEMY_DATABASE_URI)
+engine = create_engine(
+    Config.SQLALCHEMY_DATABASE_URI,
+    poolclass=QueuePool,
+    pool_size=10,
+    max_overflow=20,
+    pool_timeout=30,
+    pool_recycle=3600,
+    pool_pre_ping=True,
+)
 Session = sessionmaker(bind=engine)
 
 


### PR DESCRIPTION
Replaces the default SQLAlchemy engine with an explicit QueuePool configuration:

- `pool_size=10` — steady-state connections kept warm
- `max_overflow=20` — burst capacity above pool_size
- `pool_timeout=30` — wait for a slot before raising TimeoutError
- `pool_recycle=3600` — recycle connections every hour to dodge idle DB/firewall timeouts
- `pool_pre_ping=True` — cheap liveness check on checkout, eliminates stale-connection errors after DB restarts

Smoke-tested locally: `from config.db import engine` initialises cleanly and `engine.pool` is a `QueuePool` of size 10.

Closes #72