### PR TITLE
ci: add Trivy container scan to docker-publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,7 @@ permissions:
   packages: write
   id-token: write
   attestations: write
+  security-events: write
 
 jobs:
   build:
@@ -74,3 +75,22 @@ jobs:
           subject-name: index.docker.io/maboni82/homeassistant-tracker-${{ matrix.service }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+      - name: Run Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: maboni82/homeassistant-tracker-${{ matrix.service }}:${{ env.tag }}
+          format: sarif
+          output: trivy-${{ matrix.service }}.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          vuln-type: os,library
+          exit-code: '0'
+
+      - name: Upload Trivy SARIF to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        continue-on-error: true
+        with:
+          sarif_file: trivy-${{ matrix.service }}.sarif
+          category: trivy-${{ matrix.service }}


### PR DESCRIPTION
Adds a Trivy vulnerability scan to the docker-publish workflow:

- Runs after the build/push step on each matrix service (backend, frontend), scanning the freshly-tagged image.
- Reports CRITICAL and HIGH only, fixed advisories only (`ignore-unfixed: true`), OS + language packages.
- `exit-code: '0'` — scan never fails the workflow, results flow into the Security tab instead.
- Uploads SARIF via `github/codeql-action/upload-sarif@v3` with `continue-on-error: true` so the personal-namespace repo doesn't fail when Advanced Security isn't on the plan.
- Adds `security-events: write` to the workflow permissions (required for SARIF upload).

Validated locally with `actionlint` — no issues.

Closes #74