### PR TITLE
feat(api,frontend): date range filter for GPS logs (closes #16)

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -4,6 +4,7 @@ Defines all Flask routes for the Home Assistant Tracker API.
 """
 
 import os
+from datetime import datetime, time as dtime, timezone
 
 from flask import request, jsonify
 import requests
@@ -19,21 +20,77 @@ HA_TOKEN = os.getenv("HA_TOKEN")
 HA_API_URL = os.getenv("HA_API_URL")
 
 
+def _parse_iso_date(value, end_of_day=False):
+    """Parse an ISO date or datetime string. Returns datetime or None.
+
+    Accepts ``YYYY-MM-DD`` (interpreted as midnight UTC, or 23:59:59.999999 UTC
+    when ``end_of_day=True``) and full ISO-8601 timestamps (``end_of_day`` is
+    ignored for those — the caller already specified the exact instant they
+    want). Returns ``None`` if ``value`` is falsy. Raises ``ValueError`` on a
+    malformed input so the caller can return HTTP 400.
+
+    The ``end_of_day`` flag fixes the symmetric-single-day bug: a request like
+    ``start_date=2026-06-01&end_date=2026-06-01`` would otherwise collapse to
+    a single instant (midnight) and return no rows.
+    """
+    if not value:
+        return None
+    try:
+        # date-only fast path
+        if len(value) == 10 and value[4] == "-" and value[7] == "-":
+            d = datetime.strptime(value, "%Y-%m-%d").date()
+            t = dtime.max if end_of_day else dtime.min
+            return datetime.combine(d, t, tzinfo=timezone.utc)
+        # full ISO-8601; tolerate trailing 'Z'
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid ISO date: {value!r}") from exc
+
+
 @api_bp.route("/gps-data", methods=["GET"])
 @token_required
 def get_gps_data():
     """
-    Fetch GPS data based on user and time_range.
+    Fetch GPS data based on user, optional time_range, and optional date range.
+
+    Query parameters:
+        user (str, required): The user whose logs to return.
+        time_range (str): Relative time bucket (default ``live``). Ignored
+            when ``start_date`` or ``end_date`` is supplied.
+        start_date (str): ISO date/datetime, inclusive lower bound. Defaults
+            to midnight UTC of the current day when neither bound is given
+            and ``time_range`` is omitted.
+        end_date (str): ISO date/datetime, inclusive upper bound.
     """
     user = request.args.get("user")
     time_range = request.args.get("time_range", "live")  # default to 'live'
     device = request.args.get("device") or None
-    data = get_gps_logs(user, time_range, device=device)
+    raw_start = request.args.get("start_date")
+    raw_end = request.args.get("end_date")
 
-    if not data:
-        return jsonify({"message": "No data found!"}), 404
+    try:
+        start_date = _parse_iso_date(raw_start)
+        end_date = _parse_iso_date(raw_end, end_of_day=True)
+    except ValueError:
+        # Don't leak parser internals / user input back to the client.
+        return jsonify({"error": "Invalid start_date or end_date (use YYYY-MM-DD)"}), 400
 
-    return jsonify(data), 200
+    # If the caller passed start_date but no end_date, treat end_date as the
+    # end of that same day (so a single-day query is intuitive).
+    if start_date and not end_date and raw_start and len(raw_start) == 10:
+        end_date = start_date.replace(hour=23, minute=59, second=59, microsecond=999999)
+
+    data = get_gps_logs(
+        user,
+        time_range,
+        device=device,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+    # Always 200 — empty array is a valid result. Frontend renders the
+    # "no logs in that range" message itself.
+    return jsonify(data or []), 200
 
 
 @api_bp.route("/users", methods=["GET"])

--- a/backend/services/db_manager.py
+++ b/backend/services/db_manager.py
@@ -98,14 +98,17 @@ def save_gps_log(user, device, latitude, longitude, accuracy, timestamp):
         )
 
 
-def get_gps_logs(user, time_range, device=None):
+def get_gps_logs(user, time_range, device=None, start_date=None, end_date=None):
     """
-    Retrieve GPS logs for a given user and optional device/time range.
+    Retrieve GPS logs for a given user and optional device/time range/date range.
 
     Args:
         user (str): Username (stripped of 'person.')
         time_range (str): A time window like 'last_hour', 'last_day', etc.
         device (str, optional): Specific device to filter by.
+        start_date (datetime, optional): Inclusive lower bound on timestamp.
+            Overrides ``time_range`` when supplied.
+        end_date (datetime, optional): Inclusive upper bound on timestamp.
 
     Returns:
         list: List of GPS logs as dictionaries.
@@ -120,23 +123,32 @@ def get_gps_logs(user, time_range, device=None):
 
         query = session.query(GPSLog).filter_by(user=user)
 
-        # Time filter
-        time_map = {
-            "last_hour": timedelta(hours=1),
-            "last_2_hours": timedelta(hours=2),
-            "last_3_hours": timedelta(hours=3),
-            "last_6_hours": timedelta(hours=6),
-            "last_day": timedelta(days=1),
-            "last_7_days": timedelta(days=7),
-            "last_30_days": timedelta(days=30),
-        }
+        # Explicit date range wins over the relative time_range bucket.
+        if start_date is not None or end_date is not None:
+            if start_date is not None:
+                logger.info("Applying start_date filter: %s", start_date)
+                query = query.filter(GPSLog.timestamp >= start_date)
+            if end_date is not None:
+                logger.info("Applying end_date filter: %s", end_date)
+                query = query.filter(GPSLog.timestamp <= end_date)
+        else:
+            # Time filter
+            time_map = {
+                "last_hour": timedelta(hours=1),
+                "last_2_hours": timedelta(hours=2),
+                "last_3_hours": timedelta(hours=3),
+                "last_6_hours": timedelta(hours=6),
+                "last_day": timedelta(days=1),
+                "last_7_days": timedelta(days=7),
+                "last_30_days": timedelta(days=30),
+            }
 
-        if time_range != "live":
-            time_limit = datetime.now(timezone.utc) - time_map.get(
-                time_range, timedelta(0)
-            )
-            logger.info("Applying time filter: %s", time_limit)
-            query = query.filter(GPSLog.timestamp > time_limit)
+            if time_range != "live":
+                time_limit = datetime.now(timezone.utc) - time_map.get(
+                    time_range, timedelta(0)
+                )
+                logger.info("Applying time filter: %s", time_limit)
+                query = query.filter(GPSLog.timestamp > time_limit)
 
         if device:
             logger.info("Applying device filter: %s", device.lower())

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -32,7 +32,16 @@
                 <option value="last_day">Last Day</option>
                 <option value="last_7_days">Last 7 Days</option>
                 <option value="last_30_days">Last 1 Month</option>
+                <option value="custom">Custom date range…</option>
             </select>
+
+            <div class="date-range" id="date-range" hidden>
+                <label for="start-date">From:</label>
+                <input type="date" id="start-date">
+                <label for="end-date">To:</label>
+                <input type="date" id="end-date">
+                <button type="button" id="apply-date-range">Apply</button>
+            </div>
 
             <div class="time-info">
                 <div id="local-time"></div>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -133,10 +133,35 @@ document.addEventListener('DOMContentLoaded', function() {
 function fetchGPSData(selectedUser) {
     const timeSelect = document.getElementById('time-select');
     const timeRange = timeSelect.value;
-    const url = `${backendApiUrl}/api/gps-data?user=${selectedUser}&time_range=${timeRange}`;  // URL with selected user and time range
+
+    // Build the URL with URLSearchParams so we can layer in optional filters
+    // (device — #102, custom date range — #16) without manual string concat.
+    const params = new URLSearchParams({ user: selectedUser });
+    if (timeRange === 'custom') {
+        // Custom date range support (issue #16). When the user picks "custom",
+        // we forward start_date/end_date (YYYY-MM-DD) to the backend instead
+        // of a relative bucket. Backend accepts ISO dates and returns 200/[]
+        // when the range is empty.
+        const startDate = document.getElementById('start-date').value;
+        const endDate = document.getElementById('end-date').value;
+        if (!startDate && !endDate) {
+            // Nothing chosen yet — default to today.
+            const today = new Date().toISOString().slice(0, 10);
+            params.set('start_date', today);
+        } else {
+            if (startDate) params.set('start_date', startDate);
+            if (endDate) params.set('end_date', endDate);
+        }
+    } else {
+        params.set('time_range', timeRange);
+    }
+
+    // Optional device filter (issue #20).
     const deviceSelect = document.getElementById('device-select');
     const selectedDevice = deviceSelect ? deviceSelect.value : '';
-    const fullUrl = selectedDevice ? `${url}&device=${encodeURIComponent(selectedDevice)}` : url;
+    if (selectedDevice) params.set('device', selectedDevice);
+
+    const fullUrl = `${backendApiUrl}/api/gps-data?${params.toString()}`;
 
     fetch(fullUrl, {
         headers: {
@@ -161,6 +186,8 @@ function fetchGPSData(selectedUser) {
             errorElement.textContent = (deviceSel && deviceSel.value)
                 ? `No GPS logs for device "${deviceSel.value}" in this range.`
                 : 'No data found!';
+
+            errorElement.textContent = 'No GPS logs for the selected date range.';
             return;
         }
 
@@ -225,12 +252,33 @@ function fetchGPSData(selectedUser) {
 
 // Add event listener for time range selector to reload data
 document.getElementById('time-select').addEventListener('change', function() {
+    // Reveal the date-range pickers when the user chooses "custom".
+    const dateRange = document.getElementById('date-range');
+    if (this.value === 'custom') {
+        dateRange.hidden = false;
+    } else {
+        dateRange.hidden = true;
+    }
+
     const userSelect = document.getElementById('user-select');
-    if (userSelect.value !== '') {
+    if (userSelect.value !== '' && this.value !== 'custom') {
         fetchGPSData(userSelect.value);  // Fetch data for the selected user when the time range changes
         updateLastUpdatedTime();  // Update the "Last updated at" time when time range changes
     }
 });
+
+// "Apply" button for custom date range (issue #16). Defer the fetch until the
+// user explicitly confirms so we don't spam the backend on every date keystroke.
+const applyDateRangeBtn = document.getElementById('apply-date-range');
+if (applyDateRangeBtn) {
+    applyDateRangeBtn.addEventListener('click', function() {
+        const userSelect = document.getElementById('user-select');
+        if (userSelect.value !== '') {
+            fetchGPSData(userSelect.value);
+            updateLastUpdatedTime();
+        }
+    });
+}
 
 // Add auto-refresh functionality every 30 seconds
 setInterval(() => {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -105,6 +105,23 @@ table tbody tr:hover {
     flex-wrap: wrap;
 }
 .playback-controls button {
+
+/* Custom date range picker (issue #16) */
+.date-range {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+.date-range input[type="date"] {
+    padding: 8px;
+    font-size: 16px;
+    background-color: #e0e7ff;
+    border: 1px solid #003366;
+    border-radius: 5px;
+    color: #003366;
+}
+.date-range button {
     padding: 8px 14px;
     background-color: #005b96;
     color: #fff;
@@ -238,3 +255,6 @@ input[type="submit"] {
         font-size: 12px;
         padding: 4px;
     }}
+
+}
+.date-range button:hover { background-color: #004080; }


### PR DESCRIPTION
Closes #16.

Adds explicit `start_date` / `end_date` query parameters to `/api/gps-data`
and a "Custom date range…" option in the frontend time selector.

## Backend
- `GET /api/gps-data` now accepts `start_date` and `end_date` (ISO `YYYY-MM-DD` or full ISO-8601). When supplied, they override the relative `time_range` bucket.
- Single-day shortcut: passing only `start_date=YYYY-MM-DD` is interpreted as that whole day (midnight UTC → 23:59:59.999 UTC).
- Malformed dates → `400 {"error": "..."}`.
- Empty result is now **200 with `[]`** (previously 404). Clients should branch on `data.length === 0`, not on HTTP status.

## Frontend
- New "Custom date range…" option in the existing time-range `<select>` reveals two `<input type="date">` controls plus an "Apply" button.
- Empty-state message updated to "No GPS logs for the selected date range." (covers both relative and custom queries).

## Compatibility
- Existing callers passing only `user`/`time_range` are unaffected.
- The 404 → 200-empty change is technically a contract change, but the previous shape was inconvenient (clients had to special-case 404 even when "no data" is a valid result). Note in PR body for reviewer awareness.