### PR TITLE
feat(api,frontend): filter GPS logs by device (closes #20)

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -10,7 +10,7 @@ import requests
 from sqlalchemy import text
 
 from config.db import engine
-from services.db_manager import get_gps_logs, get_unique_users
+from services.db_manager import get_gps_logs, get_unique_users, get_devices_for_user
 from . import api_bp
 from .auth import token_required
 
@@ -27,7 +27,8 @@ def get_gps_data():
     """
     user = request.args.get("user")
     time_range = request.args.get("time_range", "live")  # default to 'live'
-    data = get_gps_logs(user, time_range)
+    device = request.args.get("device") or None
+    data = get_gps_logs(user, time_range, device=device)
 
     if not data:
         return jsonify({"message": "No data found!"}), 404
@@ -47,6 +48,19 @@ def get_users():
         return jsonify({"message": "No users found!"}), 404
 
     return jsonify(users), 200
+
+
+@api_bp.route("/users/<username>/devices", methods=["GET"])
+@token_required
+def get_user_devices(username):
+    """
+    Get the distinct device identifiers ever seen for ``username``.
+
+    Returns 200 with ``[]`` when the user has no devices (so the frontend can
+    render a friendly empty-state rather than handling a 404).
+    """
+    devices = get_devices_for_user(username)
+    return jsonify(devices or []), 200
 
 
 @api_bp.route("/healthz", methods=["GET"])

--- a/backend/services/db_manager.py
+++ b/backend/services/db_manager.py
@@ -180,3 +180,35 @@ def get_unique_users():
         session.rollback()
         logger.error("Error retrieving unique users: %s", str(e))
         return []
+
+
+def get_devices_for_user(user):
+    """
+    Get the distinct device identifiers seen in GPS logs for ``user``.
+
+    Args:
+        user (str): Username (the ``person.`` prefix is stripped if present).
+
+    Returns:
+        list[str]: Sorted list of distinct device IDs. Empty when the user
+        has no logs (rather than returning ``None``) so callers can iterate
+        unconditionally.
+    """
+    try:
+        if user.startswith("person."):
+            user = user.replace("person.", "")
+
+        rows = (
+            session.query(GPSLog.device)
+            .filter_by(user=user)
+            .distinct()
+            .all()
+        )
+        devices = sorted({row[0] for row in rows if row[0]})
+        logger.info("Found %d distinct devices for user: %s", len(devices), user)
+        return devices
+
+    except Exception as e:
+        session.rollback()
+        logger.error("Error retrieving devices for user %s: %s", user, str(e))
+        return []

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,6 +17,11 @@
                 <!-- Users will be populated here dynamically -->
             </select>
 
+            <label for="device-select">Device:</label>
+            <select id="device-select">
+                <option value="">All devices</option>
+            </select>
+
             <label for="time-select">Select Time Range:</label>
             <select id="time-select">
                 <option value="last_hour">Last Hour</option>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -83,19 +83,62 @@ function fetchUsers() {
     // Add event listener to fetch data when a valid user is selected
     userSelect.addEventListener('change', function() {
         if (userSelect.value !== '') {
+            fetchDevicesForUser(userSelect.value);
             fetchGPSData(userSelect.value);  // Fetch data for the selected user
             updateLastUpdatedTime();  // Update the "Last updated at" time when user changes
         }
     });
 }
 
+// Populate the device dropdown for the current user (issue #20). Always
+// includes an "All devices" option that maps to no device filter.
+function fetchDevicesForUser(selectedUser) {
+    const deviceSelect = document.getElementById('device-select');
+    if (!deviceSelect) return;
+    const url = `${backendApiUrl}/api/users/${encodeURIComponent(selectedUser)}/devices`;
+
+    fetch(url, { headers: { 'Authorization': `Bearer ${token}` } })
+        .then(response => response.json())
+        .then(devices => {
+            // Reset to just the "All devices" sentinel before re-populating.
+            deviceSelect.innerHTML = '<option value="">All devices</option>';
+            if (!devices || devices.length === 0) return;
+            devices.forEach(device => {
+                const option = document.createElement('option');
+                option.value = device;
+                option.textContent = device;
+                deviceSelect.appendChild(option);
+            });
+        })
+        .catch(error => {
+            console.error('Error fetching devices:', error);
+        });
+}
+
+// Re-fetch GPS data whenever the device selection changes.
+document.addEventListener('DOMContentLoaded', function() {
+    const deviceSelect = document.getElementById('device-select');
+    if (deviceSelect) {
+        deviceSelect.addEventListener('change', function() {
+            const userSelect = document.getElementById('user-select');
+            if (userSelect.value !== '') {
+                fetchGPSData(userSelect.value);
+                updateLastUpdatedTime();
+            }
+        });
+    }
+});
+
 // Fetch GPS data for the selected user and time range, and plot it on the map
 function fetchGPSData(selectedUser) {
     const timeSelect = document.getElementById('time-select');
     const timeRange = timeSelect.value;
     const url = `${backendApiUrl}/api/gps-data?user=${selectedUser}&time_range=${timeRange}`;  // URL with selected user and time range
+    const deviceSelect = document.getElementById('device-select');
+    const selectedDevice = deviceSelect ? deviceSelect.value : '';
+    const fullUrl = selectedDevice ? `${url}&device=${encodeURIComponent(selectedDevice)}` : url;
 
-    fetch(url, {
+    fetch(fullUrl, {
         headers: {
             'Authorization': `Bearer ${token}`,  // Using token from the environment
         }
@@ -114,7 +157,10 @@ function fetchGPSData(selectedUser) {
         });
 
         if (!data || data.length === 0) {
-            errorElement.textContent = 'No data found!';
+            const deviceSel = document.getElementById('device-select');
+            errorElement.textContent = (deviceSel && deviceSel.value)
+                ? `No GPS logs for device "${deviceSel.value}" in this range.`
+                : 'No data found!';
             return;
         }
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -72,7 +72,7 @@ table tbody tr:hover {
     gap: 10px;  /* Add some space between the selectors */
 }
 
-#user-select, #time-select {
+#user-select, #time-select, #device-select {
     padding: 10px;
     font-size: 16px;
     background-color: #e0e7ff;


### PR DESCRIPTION
Closes #20.

The `gps_logs` table already has a `device` column (set by the HA fetcher),
and `get_gps_logs()` already accepted an optional `device` kwarg — it just
wasn't exposed via the HTTP layer or the UI. This PR wires it up.

## Backend
- `GET /api/gps-data` now accepts `?device=<id>` and forwards it through to `get_gps_logs(..., device=...)`.
- New endpoint **`GET /api/users/<username>/devices`** returns the sorted list of distinct device IDs seen for that user. Returns `200 []` (not 404) when the user has no devices.
- New `get_devices_for_user(user)` in `services/db_manager.py`.

## Frontend
- New "Device" dropdown next to the user/time selectors. Auto-populated with the user's devices whenever the user selection changes (`fetchDevicesForUser`).
- Default option is "All devices" (empty value → no filter).
- Changing the device re-fetches GPS data.
- Empty-state message includes the device name when one is selected.

## Notes
- No DB migration needed — `device` column already exists.