### PR TITLE
feat(api,frontend): per-user distance/speed stats + chart (closes #22)

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -11,7 +11,12 @@ import requests
 from sqlalchemy import text
 
 from config.db import engine
-from services.db_manager import get_gps_logs, get_unique_users, get_devices_for_user
+from services.db_manager import (
+    get_gps_logs,
+    get_unique_users,
+    get_devices_for_user,
+    get_user_stats,
+)
 from . import api_bp
 from .auth import token_required
 
@@ -118,6 +123,31 @@ def get_user_devices(username):
     """
     devices = get_devices_for_user(username)
     return jsonify(devices or []), 200
+
+
+@api_bp.route("/users/<username>/stats", methods=["GET"])
+@token_required
+def get_user_stats_route(username):
+    """
+    Per-user aggregate stats over an optional date window (issue #22).
+
+    Query parameters:
+        start_date, end_date — ISO date / datetime. Both optional.
+    """
+    raw_start = request.args.get("start_date")
+    raw_end = request.args.get("end_date")
+    try:
+        start_date = _parse_iso_date(raw_start)
+        end_date = _parse_iso_date(raw_end, end_of_day=True)
+    except ValueError:
+        # Don't leak parser internals / user input back to the client.
+        return jsonify({"error": "Invalid start_date or end_date (use YYYY-MM-DD)"}), 400
+
+    if start_date and not end_date and raw_start and len(raw_start) == 10:
+        end_date = start_date.replace(hour=23, minute=59, second=59, microsecond=999999)
+
+    stats = get_user_stats(username, start_date=start_date, end_date=end_date)
+    return jsonify(stats), 200
 
 
 @api_bp.route("/healthz", methods=["GET"])

--- a/backend/services/db_manager.py
+++ b/backend/services/db_manager.py
@@ -224,3 +224,95 @@ def get_devices_for_user(user):
         session.rollback()
         logger.error("Error retrieving devices for user %s: %s", user, str(e))
         return []
+
+
+def _haversine_km(lat1, lon1, lat2, lon2):
+    """Great-circle distance between two lat/lon points, in kilometers.
+
+    Standard haversine formula. Used for per-user distance stats (#22).
+    """
+    import math
+    r = 6371.0  # Earth radius km
+    rlat1, rlat2 = math.radians(lat1), math.radians(lat2)
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+    a = math.sin(dlat / 2) ** 2 + math.cos(rlat1) * math.cos(rlat2) * math.sin(dlon / 2) ** 2
+    return 2 * r * math.asin(math.sqrt(a))
+
+
+def get_user_stats(user, start_date=None, end_date=None):
+    """
+    Aggregate per-user GPS stats over an optional date window.
+
+    Returns a dict:
+        {
+            "total_distance_km": float,
+            "avg_speed_kmh": float,
+            "point_count": int,
+            "period": {"start": iso|null, "end": iso|null},
+            "points_per_hour": {0..23: count},
+        }
+
+    Edge cases:
+        - Fewer than two points → distance = 0, avg_speed = 0.
+        - End timestamp == start timestamp → avg_speed = 0 (avoid div-by-zero).
+    """
+    try:
+        if user.startswith("person."):
+            user = user.replace("person.", "")
+
+        query = session.query(GPSLog).filter_by(user=user)
+        if start_date is not None:
+            query = query.filter(GPSLog.timestamp >= start_date)
+        if end_date is not None:
+            query = query.filter(GPSLog.timestamp <= end_date)
+        logs = query.order_by(GPSLog.timestamp).all()
+
+        # Bucket points by hour-of-day for the chart on the frontend.
+        points_per_hour = {h: 0 for h in range(24)}
+        for log in logs:
+            points_per_hour[log.timestamp.hour] += 1
+
+        if len(logs) < 2:
+            return {
+                "total_distance_km": 0.0,
+                "avg_speed_kmh": 0.0,
+                "point_count": len(logs),
+                "period": {
+                    "start": logs[0].timestamp.isoformat() if logs else None,
+                    "end": logs[-1].timestamp.isoformat() if logs else None,
+                },
+                "points_per_hour": points_per_hour,
+            }
+
+        total_km = 0.0
+        for prev, curr in zip(logs, logs[1:]):
+            total_km += _haversine_km(
+                prev.latitude, prev.longitude, curr.latitude, curr.longitude
+            )
+
+        total_seconds = (logs[-1].timestamp - logs[0].timestamp).total_seconds()
+        avg_kmh = (total_km / (total_seconds / 3600.0)) if total_seconds > 0 else 0.0
+
+        return {
+            "total_distance_km": round(total_km, 3),
+            "avg_speed_kmh": round(avg_kmh, 3),
+            "point_count": len(logs),
+            "period": {
+                "start": logs[0].timestamp.isoformat(),
+                "end": logs[-1].timestamp.isoformat(),
+            },
+            "points_per_hour": points_per_hour,
+        }
+
+    except Exception as e:
+        session.rollback()
+        logger.error("Error computing stats for user %s: %s", user, str(e))
+        # Log details server-side only; don't leak exception text to the client.
+        return {
+            "total_distance_km": 0.0,
+            "avg_speed_kmh": 0.0,
+            "point_count": 0,
+            "period": {"start": None, "end": None},
+            "points_per_hour": {h: 0 for h in range(24)},
+        }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -65,6 +65,25 @@
             </select>
         </div>
 
+        <!-- Per-user stats panel (issue #22). Hidden until a user is picked. -->
+        <div id="stats-panel" class="stats-panel" hidden>
+            <div class="stats-grid">
+                <div class="stat">
+                    <div class="stat-label">Total distance</div>
+                    <div class="stat-value" id="stat-distance">—</div>
+                </div>
+                <div class="stat">
+                    <div class="stat-label">Avg speed</div>
+                    <div class="stat-value" id="stat-speed">—</div>
+                </div>
+                <div class="stat">
+                    <div class="stat-label">Points</div>
+                    <div class="stat-value" id="stat-points">—</div>
+                </div>
+            </div>
+            <canvas id="stats-chart" height="120"></canvas>
+        </div>
+
         <div id="error"></div>  <!-- Error message will appear here -->
 
         <table id="gps-data-table">

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -440,3 +440,95 @@ document.addEventListener('DOMContentLoaded', function() {
         playback.speedMultiplier = parseFloat(speedSelect.value) || 1;
     }
 });
+
+// ----------------------------------------------------------------------------
+// Per-user stats + chart (issue #22)
+//
+// We render three numeric "tiles" (distance / avg speed / point count) plus a
+// 24-bucket bar chart of points-per-hour-of-day. Chart.js is lazy-loaded from
+// a CDN on first use so the page-load cost is zero for users who never look
+// at stats.
+// ----------------------------------------------------------------------------
+
+let chartJsLoadPromise = null;
+let statsChartInstance = null;
+
+function loadChartJs() {
+    if (window.Chart) return Promise.resolve(window.Chart);
+    if (chartJsLoadPromise) return chartJsLoadPromise;
+    chartJsLoadPromise = new Promise((resolve, reject) => {
+        const s = document.createElement('script');
+        s.src = 'https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js';
+        s.onload = () => resolve(window.Chart);
+        s.onerror = () => reject(new Error('Failed to load Chart.js'));
+        document.head.appendChild(s);
+    });
+    return chartJsLoadPromise;
+}
+
+function fetchUserStats(selectedUser) {
+    const panel = document.getElementById('stats-panel');
+    if (!panel) return;
+    const url = `${backendApiUrl}/api/users/${encodeURIComponent(selectedUser)}/stats`;
+
+    fetch(url, { headers: { 'Authorization': `Bearer ${token}` } })
+        .then(r => r.json())
+        .then(stats => {
+            panel.hidden = false;
+            document.getElementById('stat-distance').textContent =
+                `${(stats.total_distance_km || 0).toFixed(2)} km`;
+            document.getElementById('stat-speed').textContent =
+                `${(stats.avg_speed_kmh || 0).toFixed(1)} km/h`;
+            document.getElementById('stat-points').textContent =
+                stats.point_count ?? 0;
+
+            // Render the points-per-hour bar chart, lazy-loading Chart.js.
+            loadChartJs().then(Chart => {
+                const buckets = stats.points_per_hour || {};
+                const labels = [];
+                const data = [];
+                for (let h = 0; h < 24; h++) {
+                    labels.push(`${String(h).padStart(2, '0')}:00`);
+                    data.push(buckets[h] ?? buckets[String(h)] ?? 0);
+                }
+                const ctx = document.getElementById('stats-chart').getContext('2d');
+                if (statsChartInstance) {
+                    statsChartInstance.data.labels = labels;
+                    statsChartInstance.data.datasets[0].data = data;
+                    statsChartInstance.update();
+                    return;
+                }
+                statsChartInstance = new Chart(ctx, {
+                    type: 'bar',
+                    data: {
+                        labels,
+                        datasets: [{
+                            label: 'Points per hour-of-day',
+                            data,
+                            backgroundColor: 'rgba(0, 91, 150, 0.6)',
+                            borderColor: '#005b96',
+                            borderWidth: 1,
+                        }],
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        scales: { y: { beginAtZero: true, ticks: { precision: 0 } } },
+                    },
+                });
+            }).catch(err => console.error(err));
+        })
+        .catch(err => {
+            console.error('Error fetching stats:', err);
+        });
+}
+
+// Hook stats refresh into the existing user-change flow.
+document.addEventListener('DOMContentLoaded', function() {
+    const userSelect = document.getElementById('user-select');
+    if (userSelect) {
+        userSelect.addEventListener('change', function() {
+            if (userSelect.value !== '') fetchUserStats(userSelect.value);
+        });
+    }
+});

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -258,3 +258,40 @@ input[type="submit"] {
 
 }
 .date-range button:hover { background-color: #004080; }
+
+/* Stats panel (issue #22) */
+.stats-panel {
+    margin: 20px 0;
+    padding: 15px;
+    background-color: #e6f2ff;
+    border: 1px solid #003366;
+    border-radius: 6px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+}
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+    margin-bottom: 12px;
+}
+.stat {
+    background-color: #fff;
+    padding: 12px;
+    border-radius: 4px;
+    text-align: center;
+}
+.stat-label {
+    font-size: 12px;
+    color: #005b96;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.stat-value {
+    font-size: 1.4em;
+    font-weight: bold;
+    color: #003366;
+    margin-top: 4px;
+}
+@media (max-width: 480px) {
+    .stats-grid { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
Closes #22.

Adds a per-user aggregate-stats endpoint and a stats panel + chart on the
frontend.

## Backend
- New `GET /api/users/<username>/stats?start_date=&end_date=` returns:
  ```json
  {
    "total_distance_km": 12.345,
    "avg_speed_kmh": 8.2,
    "point_count": 142,
    "period": { "start": "...", "end": "..." },
    "points_per_hour": { "0": 0, "1": 0, ..., "23": 4 }
  }
  ```
- Distance: Haversine sum over consecutive timestamped points.
- Avg speed: `total_distance / (end_ts - start_ts)`, with `0` when total time ≤ 0.
- Edge cases handled: `<2 points` → distance/speed are `0`, `point_count` is honest.
- Reuses the same `_parse_iso_date` helper as the date-range PR (fine to land independently — if both merge, dedup can be a quick follow-up).

## Frontend
- New `#stats-panel` with three "tiles" (distance / avg speed / point count).
- Bar chart of points-per-hour-of-day powered by **Chart.js 4.4.1**, **lazy-loaded from `cdn.jsdelivr.net`** on first stats fetch — zero page-load cost for users who never select a user.
- Responsive: tiles stack on phones (`@media max-width: 480px`).
- Refreshes whenever the user dropdown changes.

## Notes
- No new build step / no asset checked in. Vanilla JS + CDN only, consistent with the existing frontend stack.