### PR TITLE
refactor(api): introduce /api/v1 with deprecation aliases (closes #78)

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -150,6 +150,29 @@ def get_user_stats_route(username):
     return jsonify(stats), 200
 
 
+@api_bp.route("/version", methods=["GET"])
+def api_version():
+    """
+    Return metadata about this API version (issue #78). Allows clients to
+    detect whether they're hitting the canonical /api/v1/* prefix or the
+    deprecated bare /api/* alias.
+    """
+    is_legacy = request.path.startswith("/api/") and not request.path.startswith(
+        "/api/v1/"
+    )
+    return (
+        jsonify(
+            {
+                "api_version": "v1",
+                "current": True,
+                "deprecated_alias": is_legacy,
+                "canonical_prefix": "/api/v1",
+            }
+        ),
+        200,
+    )
+
+
 @api_bp.route("/healthz", methods=["GET"])
 def healthz():
     """

--- a/backend/app.py
+++ b/backend/app.py
@@ -4,7 +4,7 @@ Flask application for Home Assistant Tracker.
 """
 
 import os
-from flask import Flask
+from flask import Flask, request
 from flask_cors import CORS
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
@@ -32,14 +32,41 @@ CORS(
             "origins": allowed_origins,
             "methods": ["GET", "POST", "OPTIONS"],
             "allow_headers": ["Authorization", "Content-Type"],
-            "expose_headers": ["Content-Type"],
+            "expose_headers": ["Content-Type", "Sunset", "Deprecation", "Link"],
             "supports_credentials": False,
             "max_age": 600,
         }
     },
 )
 
-app.register_blueprint(api_bp, url_prefix="/api")
+# Register the API blueprint under the versioned prefix (canonical) and the
+# legacy bare /api prefix (deprecated alias kept for one release cycle, see
+# docs/api/versioning.md).
+app.register_blueprint(api_bp, url_prefix="/api/v1")
+app.register_blueprint(api_bp, name="api_legacy", url_prefix="/api")
+
+
+# Sunset / Deprecation date for the legacy /api/* alias. ~12 months from the
+# introduction of /api/v1 (issue #78).
+LEGACY_API_SUNSET = "Sun, 06 Jun 2027 00:00:00 GMT"
+
+
+@app.after_request
+def _tag_legacy_api(response):
+    """
+    Add Sunset / Deprecation / Link headers on responses served from the
+    legacy /api/* prefix so clients can detect the deprecation in CI / logs
+    and migrate to /api/v1/*. The versioned prefix is left untouched.
+    """
+    path = request.path or ""
+    if path.startswith("/api/") and not path.startswith("/api/v1/"):
+        response.headers["Deprecation"] = "true"
+        response.headers["Sunset"] = LEGACY_API_SUNSET
+        # RFC 8288 Link header pointing to the successor resource.
+        successor = path.replace("/api/", "/api/v1/", 1)
+        response.headers["Link"] = f'<{successor}>; rel="successor-version"'
+    return response
+
 
 # Configure rate limiting to prevent API abuse
 # Default limits apply to all routes: 200 per day, 50 per hour

--- a/docs/api/versioning.md
+++ b/docs/api/versioning.md
@@ -1,0 +1,61 @@
+# API Versioning Policy
+
+_Closes #78._
+
+## Overview
+
+The Home Assistant Tracker HTTP API is versioned via a URL prefix:
+
+- **Canonical:** `/api/v1/...`
+- **Deprecated alias (legacy):** `/api/...` — kept for one release cycle, slated for removal.
+
+Clients SHOULD call `/api/v1/...` directly. Calls to the bare `/api/...`
+prefix continue to work but receive `Deprecation: true`, a `Sunset` date,
+and a `Link: <successor>; rel="successor-version"` header on every response.
+
+## Discovery
+
+```
+GET /api/v1/version
+→ { "api_version": "v1", "current": true,
+    "deprecated_alias": false, "canonical_prefix": "/api/v1" }
+```
+
+The same endpoint exists at `/api/version` and will respond with
+`"deprecated_alias": true` along with the deprecation headers.
+
+## Lifecycle
+
+Each major API version moves through three phases:
+
+| Phase       | Meaning                                                         |
+|-------------|-----------------------------------------------------------------|
+| **Active**  | Fully supported. New features land here.                        |
+| **Deprecated** | Still served, but emits `Deprecation` + `Sunset` headers. New features will NOT be added. Clients should migrate. |
+| **Retired** | Removed. Requests return `410 Gone`.                            |
+
+A version stays Deprecated for **at least 12 months** before retirement,
+giving downstream integrations time to migrate.
+
+## Current status
+
+| Prefix     | Status     | Sunset                  |
+|------------|------------|-------------------------|
+| `/api/v1`  | Active     | —                       |
+| `/api`     | Deprecated | 2027-06-06 (12 months)  |
+
+## Versioning rules
+
+- **Backwards-compatible additions** (new endpoints, new optional fields) do
+  NOT bump the version.
+- **Breaking changes** (removed/renamed fields, changed response shape,
+  changed status code semantics) require a new major version (`/api/v2`).
+- When `/api/v2` ships, `/api/v1` moves to Deprecated and starts its own
+  ≥12-month sunset clock.
+
+## Client guidance
+
+- Always send requests to `/api/v1/...`.
+- Watch for the `Deprecation` and `Sunset` response headers in CI/logs.
+- Pin to a major version in client config so a server-side rollout of
+  `/api/v2` doesn't break you implicitly.

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -45,7 +45,7 @@ function convertUTCToLocal(utcDateString) {
 // Fetch users from the API and populate the dropdown
 function fetchUsers() {
     const userSelect = document.getElementById('user-select');
-    const url = `${backendApiUrl}/api/users`;  // API endpoint for fetching users
+    const url = `${backendApiUrl}/api/v1/users`;  // API endpoint for fetching users
 
     fetch(url, {
         headers: {
@@ -95,7 +95,7 @@ function fetchUsers() {
 function fetchDevicesForUser(selectedUser) {
     const deviceSelect = document.getElementById('device-select');
     if (!deviceSelect) return;
-    const url = `${backendApiUrl}/api/users/${encodeURIComponent(selectedUser)}/devices`;
+    const url = `${backendApiUrl}/api/v1/users/${encodeURIComponent(selectedUser)}/devices`;
 
     fetch(url, { headers: { 'Authorization': `Bearer ${token}` } })
         .then(response => response.json())
@@ -161,7 +161,7 @@ function fetchGPSData(selectedUser) {
     const selectedDevice = deviceSelect ? deviceSelect.value : '';
     if (selectedDevice) params.set('device', selectedDevice);
 
-    const fullUrl = `${backendApiUrl}/api/gps-data?${params.toString()}`;
+    const fullUrl = `${backendApiUrl}/api/v1/gps-data?${params.toString()}`;
 
     fetch(fullUrl, {
         headers: {
@@ -469,7 +469,7 @@ function loadChartJs() {
 function fetchUserStats(selectedUser) {
     const panel = document.getElementById('stats-panel');
     if (!panel) return;
-    const url = `${backendApiUrl}/api/users/${encodeURIComponent(selectedUser)}/stats`;
+    const url = `${backendApiUrl}/api/v1/users/${encodeURIComponent(selectedUser)}/stats`;
 
     fetch(url, { headers: { 'Authorization': `Bearer ${token}` } })
         .then(r => r.json())


### PR DESCRIPTION
Closes #78.

## What

- Register the API blueprint at `/api/v1` (canonical) **and** keep the bare `/api` mount as a deprecated alias for one release cycle.
- Add `GET /api/v1/version` returning `{ api_version: "v1", current: true, deprecated_alias: bool, canonical_prefix: "/api/v1" }` for client discovery.
- Tag responses served from the legacy `/api/*` prefix with `Deprecation: true`, `Sunset: Sun, 06 Jun 2027 00:00:00 GMT`, and an RFC-8288 `Link: <successor>; rel="successor-version"` header.
- Frontend (`script.js`) now calls `/api/v1/...` directly so we stop relying on the deprecated alias.
- New `docs/api/versioning.md` documents the Active -> Deprecated -> Retired lifecycle and the ≥12-month sunset rule.

## Compatibility

The bare `/api/*` paths keep working — existing integrations and any unupgraded clients continue to function, just with deprecation headers. No client-visible breaking changes.