### PR TITLE
feat(gdpr): user data delete/export + consent endpoints (closes #75)

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -9,3 +9,4 @@ api_bp = Blueprint("api", __name__)
 # Import routes to register endpoints AFTER api_bp is defined.
 # noqa tells linters it's intentional and should not be moved.
 from . import routes  # noqa: C0413, F401
+from . import gdpr  # noqa: C0413, F401

--- a/backend/api/gdpr.py
+++ b/backend/api/gdpr.py
@@ -1,0 +1,180 @@
+# backend/api/gdpr.py
+"""
+GDPR compliance endpoints (issue #75).
+
+Provides per-user data export, deletion ("right to be forgotten"), and
+consent read/write under the canonical ``/api/v1/users/<username>/...``
+prefix. All endpoints require the existing bearer-token auth.
+"""
+
+import csv
+import io
+import logging
+from datetime import datetime, timezone
+
+from flask import jsonify, request, Response, stream_with_context
+from sqlalchemy.orm import sessionmaker
+
+from api.models import GPSLog, UserConsent
+from config.db import engine
+from . import api_bp
+from .auth import token_required
+
+logger = logging.getLogger(__name__)
+
+Session = sessionmaker(bind=engine)
+
+
+@api_bp.route("/users/<username>/data", methods=["DELETE"])
+@token_required
+def delete_user_data(username):
+    """
+    Delete all GPSLog rows for ``username`` (GDPR Art. 17, right to erasure).
+
+    Returns the number of rows removed. Consent rows are kept so the user's
+    withdrawal-of-consent record survives erasure of location history.
+    """
+    s = Session()
+    try:
+        deleted = s.query(GPSLog).filter(GPSLog.user == username).delete(
+            synchronize_session=False
+        )
+        s.commit()
+        logger.info("GDPR: erased %d GPS rows for user=%s", deleted, username)
+        return jsonify({"username": username, "deleted_rows": deleted}), 200
+    except Exception as exc:  # pragma: no cover - defensive
+        s.rollback()
+        logger.exception("GDPR erase failed for %s", username)
+        return jsonify({"error": "internal_error", "detail": str(exc)}), 500
+    finally:
+        s.close()
+
+
+def _rows_for_user(username):
+    s = Session()
+    try:
+        rows = (
+            s.query(GPSLog)
+            .filter(GPSLog.user == username)
+            .order_by(GPSLog.timestamp.asc())
+            .all()
+        )
+        return [r.to_dict() for r in rows]
+    finally:
+        s.close()
+
+
+@api_bp.route("/users/<username>/export", methods=["GET"])
+@token_required
+def export_user_data(username):
+    """
+    Export all GPSLog rows for ``username`` (GDPR Art. 20, data portability).
+
+    Query parameters:
+        format: ``json`` (default) or ``csv``.
+    """
+    fmt = (request.args.get("format") or "json").lower()
+    rows = _rows_for_user(username)
+
+    if fmt == "csv":
+        def generate():
+            buf = io.StringIO()
+            writer = csv.writer(buf)
+            writer.writerow(
+                ["user", "device", "latitude", "longitude", "timestamp", "accuracy"]
+            )
+            yield buf.getvalue()
+            buf.seek(0)
+            buf.truncate(0)
+            for r in rows:
+                writer.writerow(
+                    [
+                        r["user"],
+                        r["device"],
+                        r["latitude"],
+                        r["longitude"],
+                        r["timestamp"],
+                        r["accuracy"],
+                    ]
+                )
+                yield buf.getvalue()
+                buf.seek(0)
+                buf.truncate(0)
+
+        filename = f"{username}-gps-export.csv"
+        return Response(
+            stream_with_context(generate()),
+            mimetype="text/csv",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    if fmt != "json":
+        return jsonify({"error": "format must be json or csv"}), 400
+
+    return jsonify({"username": username, "count": len(rows), "rows": rows}), 200
+
+
+@api_bp.route("/users/<username>/consent", methods=["GET"])
+@token_required
+def get_user_consent(username):
+    """
+    Read the consent record for ``username``. Returns a default
+    no-consent record if none has ever been stored.
+    """
+    s = Session()
+    try:
+        row = s.get(UserConsent, username)
+        if row is None:
+            return (
+                jsonify(
+                    {
+                        "username": username,
+                        "has_consent": False,
+                        "consent_given_at": None,
+                        "consent_withdrawn_at": None,
+                        "policy_version": None,
+                    }
+                ),
+                200,
+            )
+        return jsonify(row.to_dict()), 200
+    finally:
+        s.close()
+
+
+@api_bp.route("/users/<username>/consent", methods=["POST"])
+@token_required
+def set_user_consent(username):
+    """
+    Record or withdraw consent for ``username``.
+
+    Body: ``{ "consent": true|false, "policy_version": "1.0" }``.
+    """
+    data = request.get_json(silent=True) or {}
+    consent = bool(data.get("consent"))
+    policy_version = data.get("policy_version")
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    s = Session()
+    try:
+        row = s.get(UserConsent, username)
+        if row is None:
+            row = UserConsent(username=username)
+            s.add(row)
+        row.has_consent = consent
+        if consent:
+            row.consent_given_at = now
+            row.consent_withdrawn_at = None
+        else:
+            row.consent_withdrawn_at = now
+        if policy_version:
+            row.policy_version = str(policy_version)
+        s.commit()
+        s.refresh(row)
+        return jsonify(row.to_dict()), 200
+    except Exception as exc:  # pragma: no cover - defensive
+        s.rollback()
+        logger.exception("GDPR consent write failed for %s", username)
+        return jsonify({"error": "internal_error", "detail": str(exc)}), 500
+    finally:
+        s.close()

--- a/backend/api/gdpr.py
+++ b/backend/api/gdpr.py
@@ -45,7 +45,7 @@ def delete_user_data(username):
     except Exception as exc:  # pragma: no cover - defensive
         s.rollback()
         logger.exception("GDPR erase failed for %s", username)
-        return jsonify({"error": "internal_error", "detail": str(exc)}), 500
+        return jsonify({"error": "internal_error"}), 500
     finally:
         s.close()
 
@@ -175,6 +175,6 @@ def set_user_consent(username):
     except Exception as exc:  # pragma: no cover - defensive
         s.rollback()
         logger.exception("GDPR consent write failed for %s", username)
-        return jsonify({"error": "internal_error", "detail": str(exc)}), 500
+        return jsonify({"error": "internal_error"}), 500
     finally:
         s.close()

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -3,8 +3,40 @@
 Database models for Home Assistant Tracker.
 """
 
-from sqlalchemy import Column, Integer, String, Float, DateTime
+from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean
 from config.db import Base
+
+
+class UserConsent(Base):
+    """
+    Tracks GDPR consent (issue #75) for a username. Users are env-driven via
+    HA_USERS, so we don't have a real user table; we key consent records by
+    username alone. ``consent_given_at`` is NULL until the user explicitly
+    opts in.
+    """
+
+    __tablename__ = "user_consent"
+
+    username = Column(String, primary_key=True)
+    consent_given_at = Column(DateTime, nullable=True)
+    consent_withdrawn_at = Column(DateTime, nullable=True)
+    policy_version = Column(String, nullable=True)
+    has_consent = Column(Boolean, nullable=False, default=False)
+
+    def to_dict(self) -> dict:
+        return {
+            "username": self.username,
+            "has_consent": bool(self.has_consent),
+            "consent_given_at": (
+                self.consent_given_at.isoformat() if self.consent_given_at else None
+            ),
+            "consent_withdrawn_at": (
+                self.consent_withdrawn_at.isoformat()
+                if self.consent_withdrawn_at
+                else None
+            ),
+            "policy_version": self.policy_version,
+        }
 
 
 class GPSLog(Base):

--- a/docs/compliance/privacy.md
+++ b/docs/compliance/privacy.md
@@ -1,0 +1,93 @@
+# Privacy & GDPR Compliance
+
+_Closes #75._
+
+## Data we collect
+
+Home Assistant Tracker stores **GPS location history** fetched from a
+configured Home Assistant instance:
+
+| Field      | Purpose                                                        |
+|------------|----------------------------------------------------------------|
+| `user`     | The Home Assistant person entity (e.g. `alice`).               |
+| `device`   | The device tracker entity (e.g. `alice_phone`).                |
+| `latitude` / `longitude` | Reported coordinates.                            |
+| `accuracy` | Reported accuracy radius in metres.                            |
+| `timestamp`| When the point was sampled.                                    |
+
+We do **not** collect: contact details, browsing data, contents of messages,
+or any data outside Home Assistant's device-tracker entities.
+
+## Lawful basis
+
+This is a self-hosted operator-deployed application. The operator (the
+person running the Docker stack) is the **data controller**. The lawful
+basis is usually **legitimate interest** (household / family location
+awareness) or **explicit consent** (where applicable). Operators are
+responsible for collecting consent from tracked users before deployment.
+
+## User rights (GDPR Arts. 15-21)
+
+The following endpoints implement the practical mechanics:
+
+| Right                          | Endpoint                                              |
+|--------------------------------|--------------------------------------------------------|
+| Right to access / portability  | `GET /api/v1/users/<username>/export?format=json\|csv`  |
+| Right to erasure ("forgotten") | `DELETE /api/v1/users/<username>/data`                |
+| Consent read                   | `GET /api/v1/users/<username>/consent`                |
+| Consent grant / withdraw       | `POST /api/v1/users/<username>/consent`               |
+
+All four endpoints require the standard `Authorization: Bearer ...` header.
+
+### Example: export as CSV
+
+```
+curl -H "Authorization: Bearer $TOKEN" \
+  "$BACKEND/api/v1/users/alice/export?format=csv" \
+  -o alice-export.csv
+```
+
+### Example: record consent
+
+```
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"consent": true, "policy_version": "1.0"}' \
+  $BACKEND/api/v1/users/alice/consent
+```
+
+### Example: erase all data for a user
+
+```
+curl -X DELETE -H "Authorization: Bearer $TOKEN" \
+  $BACKEND/api/v1/users/alice/data
+```
+
+Erasure removes all `gps_logs` rows for that user. The `user_consent`
+row is intentionally preserved so a "withdrew consent at <timestamp>"
+audit record survives the erasure.
+
+## Retention policy (proposed)
+
+| Tier              | Retention                |
+|-------------------|--------------------------|
+| Raw GPS points    | **180 days** by default. |
+| Aggregated stats  | Indefinite (no PII).     |
+| Consent records   | Lifetime of installation.|
+| Database backups  | **30 days** (see `docs/operations/backup-restore.md`). |
+
+Retention is enforced by the operator. A scheduled cleanup job is tracked
+separately and is out of scope for #75.
+
+## Storage location
+
+All data lives in the Postgres database configured via `DATABASE_URL`. No
+data is sent to third parties unless the operator has explicitly configured
+S3 backup uploads (`S3_BUCKET`); in that case the operator is responsible
+for ensuring the bucket region and encryption satisfy their jurisdiction.
+
+## Contact
+
+Issues / data-subject requests against a specific deployment should be
+directed at the operator running that deployment, not the upstream
+maintainers.


### PR DESCRIPTION
Closes #75.

## What

Implements GDPR Art. 15-21 mechanics on the canonical `/api/v1` prefix.

### New endpoints (all bearer-token auth)

- `DELETE /api/v1/users/<username>/data` — right to erasure. Removes all `gps_logs` rows for the user; returns the deleted-row count. Consent rows are intentionally preserved so a withdrawal-of-consent audit row survives erasure.
- `GET /api/v1/users/<username>/export?format=json|csv` — right to portability. Streams all GPS rows for the user.
- `GET /api/v1/users/<username>/consent` — read the consent record.
- `POST /api/v1/users/<username>/consent` — grant or withdraw consent. Body: `{"consent": true|false, "policy_version": "1.0"}`.

### Schema

New `UserConsent` SQLAlchemy model → `user_consent` table, auto-created by `Base.metadata.create_all` on startup. Users remain env-driven (`HA_USERS`), so the consent row is keyed by `username` alone — no user table required (simplest workable shape per the issue brief).

### Docs

`docs/compliance/privacy.md` documents data collected, lawful basis, the four endpoints with curl examples, and a proposed retention policy (raw points 180d, backups 30d, consent indefinite).